### PR TITLE
feat: expose annotation presence with condition result

### DIFF
--- a/src/testModifier.ts
+++ b/src/testModifier.ts
@@ -40,11 +40,12 @@ export class TestModifier {
     if (processed.condition) {
       this._slow = true;
       this._timeout *= 3;
-      this._annotations.push({
-        type: 'slow',
-        description: processed.description
-      });
     }
+    this._annotations.push({
+      type: 'slow',
+      condition: processed.condition,
+      description: processed.description
+    });
   }
 
   skip(): void;
@@ -53,13 +54,13 @@ export class TestModifier {
   skip(condition: boolean, description: string): void;
   skip(arg?: boolean | string, description?: string) {
     const processed = this._interpretCondition(arg, description);
-    if (processed.condition) {
+    if (processed.condition)
       this._skipped = true;
-      this._annotations.push({
-        type: 'skip',
-        description: processed.description
-      });
-    }
+    this._annotations.push({
+      type: 'skip',
+      condition: processed.condition,
+      description: processed.description
+    });
   }
 
   fixme(): void;
@@ -68,13 +69,13 @@ export class TestModifier {
   fixme(condition: boolean, description: string): void;
   fixme(arg?: boolean | string, description?: string) {
     const processed = this._interpretCondition(arg, description);
-    if (processed.condition) {
+    if (processed.condition)
       this._skipped = true;
-      this._annotations.push({
-        type: 'fixme',
-        description: processed.description
-      });
-    }
+    this._annotations.push({
+      type: 'fixme',
+      condition: processed.condition,
+      description: processed.description
+    });
   }
 
   flaky(): void;
@@ -83,13 +84,13 @@ export class TestModifier {
   flaky(condition: boolean, description: string): void;
   flaky(arg?: boolean | string, description?: string) {
     const processed = this._interpretCondition(arg, description);
-    if (processed.condition) {
+    if (processed.condition)
       this._flaky = true;
-      this._annotations.push({
-        type: 'flaky',
-        description: processed.description
-      });
-    }
+    this._annotations.push({
+      type: 'flaky',
+      condition: processed.condition,
+      description: processed.description
+    });
   }
 
   fail(): void;
@@ -98,13 +99,13 @@ export class TestModifier {
   fail(condition: boolean, description: string): void;
   fail(arg?: boolean | string, description?: string) {
     const processed = this._interpretCondition(arg, description);
-    if (processed.condition) {
+    if (processed.condition)
       this._expectedStatus = 'failed';
-      this._annotations.push({
-        type: 'fail',
-        description: processed.description
-      });
-    }
+    this._annotations.push({
+      type: 'fail',
+      condition: processed.condition,
+      description: processed.description
+    });
   }
 
   private _interpretCondition(arg?: boolean | string, description?: string): { condition: boolean, description?: string } {

--- a/test/list-mode.spec.ts
+++ b/test/list-mode.spec.ts
@@ -75,13 +75,17 @@ it('should emit test annotations', async ({ runInlineTest }) => {
     'a.test.js': `
       it('should emit annotation', (test, parameters) => {
         test.fail(true, 'Fail annotation');
+        test.fixme(false, 'fixme annotation');
       }, async ({}) => {
         expect(true).toBe(false);
       });
     `
   }, { 'list': true });
   expect(result.exitCode).toBe(0);
-  expect(result.report.suites[0].specs[0].tests[0].annotations).toEqual([{ type: 'fail', description: 'Fail annotation', condition: true, }]);
+  expect(result.report.suites[0].specs[0].tests[0].annotations).toEqual([
+    { type: 'fail', description: 'Fail annotation', condition: true, },
+    { type: 'fixme', description: 'fixme annotation', condition: false, },
+  ]);
 });
 
 it('should emit suite annotations', async ({ runInlineTest }) => {

--- a/test/list-mode.spec.ts
+++ b/test/list-mode.spec.ts
@@ -81,7 +81,7 @@ it('should emit test annotations', async ({ runInlineTest }) => {
     `
   }, { 'list': true });
   expect(result.exitCode).toBe(0);
-  expect(result.report.suites[0].specs[0].tests[0].annotations).toEqual([{ type: 'fail', description: 'Fail annotation' }]);
+  expect(result.report.suites[0].specs[0].tests[0].annotations).toEqual([{ type: 'fail', description: 'Fail annotation', condition: true, }]);
 });
 
 it('should emit suite annotations', async ({ runInlineTest }) => {
@@ -97,5 +97,5 @@ it('should emit suite annotations', async ({ runInlineTest }) => {
     `
   }, { 'list': true });
   expect(result.exitCode).toBe(0);
-  expect(result.report.suites[0].suites[0].specs[0].tests[0].annotations).toEqual([{ type: 'fixme', description: 'Fix me!' }]);
+  expect(result.report.suites[0].suites[0].specs[0].tests[0].annotations).toEqual([{ type: 'fixme', description: 'Fix me!', condition: true }]);
 });


### PR DESCRIPTION
Currently, json reporter reports only applied annotationes.
However, annotations dashboard doesn't care if the annotation applied
per se, but rather if it is present in code with some condition.

In other words, for the Annotations Dashboard test is flaky if it is
flaky under some conditions.