### PR TITLE
api(reporter, breaking): remove file from onError

### DIFF
--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -24,7 +24,7 @@ export interface Reporter {
   onStdErr(chunk: string | Buffer, test?: Test): void;
   onTestEnd(test: Test, result: TestResult): void;
   onTimeout(timeout: number): void;
-  onError(error: TestError, file?: string): void;
+  onError(error: TestError): void;
   onEnd(): void;
 }
 
@@ -35,6 +35,6 @@ export class EmptyReporter implements Reporter {
   onStdErr(chunk: string | Buffer, test?: Test) {}
   onTestEnd(test: Test, result: TestResult) {}
   onTimeout(timeout: number) {}
-  onError(error: any, file?: string) {}
+  onError(error: TestError) {}
   onEnd() {}
 }

--- a/src/reporters/base.ts
+++ b/src/reporters/base.ts
@@ -63,8 +63,8 @@ export class BaseReporter implements Reporter  {
     this.fileDurations.set(spec.file, duration);
   }
 
-  onError(error: TestError, file?: string) {
-    console.log(formatError(error, file));
+  onError(error: TestError) {
+    console.log(formatError(error));
   }
 
   onTimeout(timeout: number) {

--- a/src/reporters/json.ts
+++ b/src/reporters/json.ts
@@ -30,14 +30,15 @@ export interface SerializedSuite {
 
 export type ReportFormat = {
   config: Config;
-  errors?: { file: string, error: TestError }[];
+  // TODO: remove the extra object wrapper.
+  errors?: { error: TestError }[];
   suites?: SerializedSuite[];
 };
 
 class JSONReporter extends EmptyReporter {
   config: Config;
   suite: Suite;
-  private _errors: { file: string, error: TestError }[] = [];
+  private _errors: { error: TestError }[] = [];
 
   onBegin(config: Config, suite: Suite) {
     this.config = config;
@@ -48,8 +49,8 @@ class JSONReporter extends EmptyReporter {
     this.onEnd();
   }
 
-  onError(error: TestError, file?: string): void {
-    this._errors.push({ file, error });
+  onError(error: TestError): void {
+    this._errors.push({ error });
   }
 
   onEnd() {

--- a/src/reporters/multiplexer.ts
+++ b/src/reporters/multiplexer.ts
@@ -60,8 +60,8 @@ export class Multiplexer implements Reporter {
       reporter.onEnd();
   }
 
-  onError(error: TestError, file?: string) {
+  onError(error: TestError) {
     for (const reporter of this._reporters)
-      reporter.onError(error, file);
+      reporter.onError(error);
   }
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -97,3 +97,14 @@ export function monotonicTime(): number {
   const [seconds, nanoseconds] = process.hrtime();
   return seconds * 1000 + (nanoseconds / 1000000 | 0);
 }
+
+export function prependErrorMessage(e: Error, message: string) {
+  let stack = e.stack || '';
+  if (stack.includes(e.message))
+    stack = stack.substring(stack.indexOf(e.message) + e.message.length);
+  let m = e.message;
+  if (m.startsWith('Error:'))
+    m = m.substring('Error:'.length);
+  e.message = message + m;
+  e.stack = e.message + stack;
+}

--- a/test/exit-code.spec.ts
+++ b/test/exit-code.spec.ts
@@ -15,7 +15,7 @@
  */
 
 import path from 'path';
-import { folio } from './fixtures';
+import { folio, stripAscii } from './fixtures';
 const { it, expect } = folio;
 
 function monotonicTime(): number {
@@ -34,10 +34,7 @@ it('should collect stdio', async ({ runTest }) => {
 
 it('should work with not defined errors', async ({runTest}) => {
   const result = await runTest('is-not-defined-error.ts');
-  const { errors } = result.report;
-  expect(errors.length).toBe(1);
-  expect(errors[0].file).toContain('assets' + path.sep + 'is-not-defined-error.ts');
-  expect(errors[0].error.message).toContain('foo is not defined');
+  expect(stripAscii(result.output)).toContain('foo is not defined');
   expect(result.exitCode).toBe(1);
 });
 

--- a/test/fixture-errors.spec.ts
+++ b/test/fixture-errors.spec.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { folio, firstStackFrame } from './fixtures';
+import { folio, firstStackFrame, stripAscii } from './fixtures';
 const { it, expect } = folio;
 
 it('should handle fixture timeout', async ({ runInlineFixturesTest }) => {
@@ -105,7 +105,7 @@ it('should throw when overriding non-defined worker fixture', async ({ runInline
       it('works', async ({foo}) => {});
     `
   });
-  expect(result.report.errors[0].error.message).toContain(`Fixture "foo" has not been registered yet. Use 'init' instead.`);
+  expect(stripAscii(result.output)).toContain(`Fixture "foo" has not been registered yet. Use 'init' instead.`);
   expect(result.exitCode).toBe(1);
 });
 
@@ -123,7 +123,7 @@ it('should throw when defining worker fixture twice', async ({ runInlineFixtures
       it('works', async ({foo}) => {});
     `
   });
-  expect(result.report.errors[0].error.message).toContain(`Fixture "foo" has already been registered. Use 'override' to override it in a specific test file.`);
+  expect(stripAscii(result.output)).toContain(`Fixture "foo" has already been registered. Use 'override' to override it in a specific test file.`);
   expect(result.exitCode).toBe(1);
 });
 
@@ -138,7 +138,7 @@ it('should throw when overriding non-defined test fixture', async ({ runInlineFi
       it('works', async ({foo}) => {});
     `
   });
-  expect(result.report.errors[0].error.message).toContain(`Fixture "foo" has not been registered yet. Use 'init' instead.`);
+  expect(stripAscii(result.output)).toContain(`Fixture "foo" has not been registered yet. Use 'init' instead.`);
   expect(result.exitCode).toBe(1);
 });
 
@@ -156,7 +156,7 @@ it('should throw when defining test fixture twice', async ({ runInlineFixturesTe
       it('works', async ({foo}) => {});
     `
   });
-  expect(result.report.errors[0].error.message).toContain(`Fixture "foo" has already been registered. Use 'override' to override it in a specific test file.`);
+  expect(stripAscii(result.output)).toContain(`Fixture "foo" has already been registered. Use 'override' to override it in a specific test file.`);
   expect(result.exitCode).toBe(1);
 });
 
@@ -174,7 +174,7 @@ it('should throw when defining test fixture with the same name as a worker fixtu
       it('works', async ({foo}) => {});
     `,
   });
-  expect(result.report.errors[0].error.message).toContain(`Fixture "foo" has already been registered as a { scope: 'worker' } fixture. Use a different name for this test fixture.`);
+  expect(stripAscii(result.output)).toContain(`Fixture "foo" has already been registered as a { scope: 'worker' } fixture. Use a different name for this test fixture.`);
   expect(result.exitCode).toBe(1);
 });
 
@@ -192,7 +192,7 @@ it('should throw when defining worker fixture with the same name as a test fixtu
       it('works', async ({foo}) => {});
     `,
   });
-  expect(result.report.errors[0].error.message).toContain(`Fixture "foo" has already been registered as a { scope: 'test' } fixture. Use a different name for this worker fixture.`);
+  expect(stripAscii(result.output)).toContain(`Fixture "foo" has already been registered as a { scope: 'test' } fixture. Use a different name for this worker fixture.`);
   expect(result.exitCode).toBe(1);
 });
 
@@ -210,7 +210,7 @@ it('should throw when worker fixture depends on a test fixture', async ({ runInl
       it('works', async ({bar}) => {});
     `,
   });
-  expect(result.report.errors[0].error.message).toContain('Worker fixture "bar" cannot depend on a test fixture "foo".');
+  expect(stripAscii(result.output)).toContain('Worker fixture "bar" cannot depend on a test fixture "foo".');
   expect(result.exitCode).toBe(1);
 });
 
@@ -257,7 +257,7 @@ it('should detect fixture dependency cycle', async ({ runInlineFixturesTest }) =
       it('works', async ({foo}) => {});
     `,
   });
-  expect(result.report.errors[0].error.message).toContain('Fixtures "foo" -> "bar" -> "baz" -> "qux" -> "foo" form a dependency cycle.');
+  expect(stripAscii(result.output)).toContain('Fixtures "foo" -> "bar" -> "baz" -> "qux" -> "foo" form a dependency cycle.');
   expect(result.exitCode).toBe(1);
 });
 
@@ -277,8 +277,8 @@ it('should throw when fixture is redefined in union', async ({ runInlineFixtures
       });
     `,
   });
-  expect(result.report.errors[0].error.message).toContain('Fixture "foo" is defined in both fixture sets.');
-  expect(firstStackFrame(result.report.errors[0].error.stack)).toContain('a.test.js:10');
+  expect(stripAscii(result.output)).toContain('Fixture "foo" is defined in both fixture sets.');
+  expect(firstStackFrame(stripAscii(result.output))).toContain('a.test.js:10');
 });
 
 it('should throw when mixing different fixture objects', async ({ runInlineFixturesTest }) => {
@@ -300,8 +300,8 @@ it('should throw when mixing different fixture objects', async ({ runInlineFixtu
       });
     `,
   });
-  expect(result.report.errors[0].error.message).toContain('Mixing different fixture sets in the same suite.');
-  expect(firstStackFrame(result.report.errors[0].error.stack)).toContain('a.test.js:14');
+  expect(stripAscii(result.output)).toContain('Mixing different fixture sets in the same suite.');
+  expect(firstStackFrame(stripAscii(result.output))).toContain('a.test.js:14');
 });
 
 it('should not reuse fixtures from one file in another one', async ({ runInlineFixturesTest }) => {
@@ -318,9 +318,8 @@ it('should not reuse fixtures from one file in another one', async ({ runInlineF
       it('test2', async ({foo}) => {});
     `,
   });
-  expect(result.report.errors[0].error.message).toBe('Test has unknown parameter "foo".');
-  expect(firstStackFrame(result.report.errors[0].error.stack)).toContain('b.spec.ts:6');
-  expect(result.results.length).toBe(1);
+  expect(stripAscii(result.output)).toContain('Test has unknown parameter "foo".');
+  expect(firstStackFrame(stripAscii(result.output))).toContain('b.spec.ts:6');
 });
 
 it('should detect a cycle in the union', async ({ runInlineFixturesTest }) => {
@@ -346,8 +345,8 @@ it('should detect a cycle in the union', async ({ runInlineFixturesTest }) => {
       });
     `,
   });
-  expect(result.report.errors[0].error.message).toContain('Fixtures "foo" -> "bar" -> "foo" form a dependency cycle.');
-  expect(firstStackFrame(result.report.errors[0].error.stack)).toContain('a.test.js:17');
+  expect(stripAscii(result.output)).toContain('Fixtures "foo" -> "bar" -> "foo" form a dependency cycle.');
+  expect(firstStackFrame(stripAscii(result.output))).toContain('a.test.js:17');
 });
 
 it('should throw for cycle in two overrides', async ({ runInlineFixturesTest }) => {
@@ -364,8 +363,8 @@ it('should throw for cycle in two overrides', async ({ runInlineFixturesTest }) 
       });
     `,
   });
-  expect(result.report.errors[0].error.message).toContain('Fixtures "foo" -> "bar" -> "foo" form a dependency cycle.');
-  expect(firstStackFrame(result.report.errors[0].error.stack)).toContain('a.test.js:9');
+  expect(stripAscii(result.output)).toContain('Fixtures "foo" -> "bar" -> "foo" form a dependency cycle.');
+  expect(firstStackFrame(stripAscii(result.output))).toContain('a.test.js:9');
 });
 
 it('should throw when overridden worker fixture depends on a test fixture', async ({ runInlineFixturesTest }) => {
@@ -379,7 +378,7 @@ it('should throw when overridden worker fixture depends on a test fixture', asyn
       it('works', async ({bar}) => {});
     `,
   });
-  expect(result.report.errors[0].error.message).toContain('Worker fixture "bar" cannot depend on a test fixture "foo".');
+  expect(stripAscii(result.output)).toContain('Worker fixture "bar" cannot depend on a test fixture "foo".');
   expect(result.exitCode).toBe(1);
 });
 
@@ -393,7 +392,7 @@ it('should throw when modifying builder after calling build', async ({ runInline
       it('works', async ({foo}) => {});
     `,
   });
-  expect(result.report.errors[0].error.message).toContain('Should not modify fixtures after build()');
+  expect(stripAscii(result.output)).toContain('Should not modify fixtures after build()');
   expect(result.exitCode).toBe(1);
 });
 
@@ -407,7 +406,7 @@ it('should throw when building twice', async ({ runInlineFixturesTest }) => {
       it('works', async ({foo}) => {});
     `,
   });
-  expect(result.report.errors[0].error.message).toContain('Should not call build() twice');
+  expect(stripAscii(result.output)).toContain('Should not call build() twice');
   expect(result.exitCode).toBe(1);
 });
 

--- a/test/fixtures.spec.ts
+++ b/test/fixtures.spec.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { firstStackFrame, folio } from './fixtures';
+import { firstStackFrame, folio, stripAscii } from './fixtures';
 const { it, expect } = folio;
 
 it('should work', async ({ runInlineFixturesTest }) => {
@@ -100,8 +100,8 @@ it('should fail if parameters are not destructured', async ({ runInlineFixturesT
       });
     `,
   });
-  expect(result.report.errors[0].error.message).toBe('First argument must use the object destructuring pattern: abc');
-  expect(firstStackFrame(result.report.errors[0].error.stack)).toContain('a.test.js:10');
+  expect(stripAscii(result.output)).toContain('First argument must use the object destructuring pattern: abc');
+  expect(firstStackFrame(stripAscii(result.output))).toContain('a.test.js:10');
   expect(result.results.length).toBe(0);
 });
 
@@ -113,8 +113,8 @@ it('should fail with an unknown fixture', async ({ runInlineTest }) => {
       });
     `,
   });
-  expect(result.report.errors[0].error.message).toBe('Test has unknown parameter "asdf".');
-  expect(firstStackFrame(result.report.errors[0].error.stack)).toContain('a.test.js:5');
+  expect(stripAscii(result.output)).toContain('Test has unknown parameter "asdf".');
+  expect(firstStackFrame(stripAscii(result.output))).toContain('a.test.js:5');
   expect(result.results.length).toBe(0);
 });
 

--- a/test/hooks.spec.ts
+++ b/test/hooks.spec.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { firstStackFrame, folio } from './fixtures';
+import { firstStackFrame, folio, stripAscii } from './fixtures';
 const { it, expect } = folio;
 
 it('hooks should work with fixtures', async ({ runInlineFixturesTest }) => {
@@ -128,7 +128,7 @@ it('beforeEach failure should prevent the test, but not other hooks', async ({ r
 });
 
 it('should throw when hook is called in fixutres file', async ({ runInlineTest }) => {
-  const report = await runInlineTest({
+  const result = await runInlineTest({
     'fixture.js': `
       folio.beforeEach(async ({}) => {});
     `,
@@ -138,11 +138,11 @@ it('should throw when hook is called in fixutres file', async ({ runInlineTest }
       });
     `,
   });
-  expect(report.report.errors[0].error.message).toContain('beforeEach hook should be called inside a describe block. Consider using an auto fixture.');
+  expect(stripAscii(result.output)).toContain('beforeEach hook should be called inside a describe block. Consider using an auto fixture.');
 });
 
 it('should throw when hook is called without describe', async ({ runInlineFixturesTest }) => {
-  const report = await runInlineFixturesTest({
+  const result = await runInlineFixturesTest({
     'a.test.js': `
       const { it, beforeEach } = baseFolio;
       beforeEach(async ({}) => {});
@@ -150,7 +150,7 @@ it('should throw when hook is called without describe', async ({ runInlineFixtur
       });
     `,
   });
-  expect(report.report.errors[0].error.message).toContain('beforeEach hook should be called inside a describe block. Consider using an auto fixture.');
+  expect(stripAscii(result.output)).toContain('beforeEach hook should be called inside a describe block. Consider using an auto fixture.');
 });
 
 it('should throw when hook depends on unknown fixture', async ({ runInlineFixturesTest }) => {
@@ -163,8 +163,8 @@ it('should throw when hook depends on unknown fixture', async ({ runInlineFixtur
       });
     `,
   });
-  expect(result.report.errors[0].error.message).toContain('beforeEach hook has unknown parameter "foo".');
-  expect(firstStackFrame(result.report.errors[0].error.stack)).toContain('a.spec.ts:6');
+  expect(stripAscii(result.output)).toContain('beforeEach hook has unknown parameter "foo".');
+  expect(firstStackFrame(stripAscii(result.output))).toContain('a.spec.ts:6');
   expect(result.exitCode).toBe(1);
 });
 
@@ -182,8 +182,8 @@ it('should throw when beforeAll hook depends on test fixture', async ({ runInlin
       });
     `,
   });
-  expect(result.report.errors[0].error.message).toContain('beforeAll hook cannot depend on a test fixture "foo".');
-  expect(firstStackFrame(result.report.errors[0].error.stack)).toContain('a.spec.ts:10');
+  expect(stripAscii(result.output)).toContain('beforeAll hook cannot depend on a test fixture "foo".');
+  expect(firstStackFrame(stripAscii(result.output))).toContain('a.spec.ts:10');
   expect(result.exitCode).toBe(1);
 });
 
@@ -201,8 +201,8 @@ it('should throw when afterAll hook depends on test fixture', async ({ runInline
       });
     `,
   });
-  expect(result.report.errors[0].error.message).toContain('afterAll hook cannot depend on a test fixture "foo".');
-  expect(firstStackFrame(result.report.errors[0].error.stack)).toContain('a.spec.ts:10');
+  expect(stripAscii(result.output)).toContain('afterAll hook cannot depend on a test fixture "foo".');
+  expect(firstStackFrame(stripAscii(result.output))).toContain('a.spec.ts:10');
   expect(result.exitCode).toBe(1);
 });
 
@@ -227,7 +227,7 @@ it('should throw when hook uses different fixtures set than describe', async ({ 
       });
     `,
   });
-  expect(result.report.errors[0].error.message).toContain('Using afterAll hook from a different fixture set.');
-  expect(firstStackFrame(result.report.errors[0].error.stack)).toContain('a.spec.ts:17');
+  expect(stripAscii(result.output)).toContain('Using afterAll hook from a different fixture set.');
+  expect(firstStackFrame(stripAscii(result.output))).toContain('a.spec.ts:17');
   expect(result.exitCode).toBe(1);
 });


### PR DESCRIPTION
We used to issue `onError` with a file before `onBegin`, when getting a syntax error or a fixture validation error while
reading one of the test files. Now, we just exit immediately instead.

If importing was successful, we start running the tests and report worker errors through `Reporter.onError()`.

Fixes #2.