### PR TITLE
api(parameters): make parameters per-folio, not global

### DIFF
--- a/src/fixtures.ts
+++ b/src/fixtures.ts
@@ -31,6 +31,11 @@ type FixtureRegistration = {
   super?: FixtureRegistration;
 };
 
+type ParameterRegistration = {
+  name: string;
+  values: any[];
+};
+
 export type TestInfo = {
   // Declaration
   title: string;
@@ -72,23 +77,12 @@ export function currentTestInfo(): TestInfo | null {
   return currentTestInfoValue;
 }
 
-export type ParameterRegistration = {
+export type ParameterDescription = {
   name: string;
   description: string;
-  defaultValue: string | number | boolean;
+  type: 'boolean' | 'number' | 'string';
 };
-export const parameterRegistrations = new Map<string, ParameterRegistration>();
-export let parameters: Parameters = {};
-export function assignParameters(params: any) {
-  parameters = Object.assign(parameters, params);
-}
-
-export const matrix: { [name: string]: any } = {};
-export function setParameterValues(name: string, values: any[]) {
-  if (!(name in matrix))
-    throw errorWithCallLocation(`Unregistered parameter '${name}' was set.`);
-  matrix[name] = values;
-}
+export const globalParameterDescriptions = new Map<string, ParameterDescription>();
 
 export let config: Config = {} as any;
 export function assignConfig(c: Config) {
@@ -99,7 +93,7 @@ class Fixture {
   pool: FixturePool;
   registration: FixtureRegistration;
   usages: Set<Fixture>;
-  hasGeneratorValue: boolean;
+  hasBuiltinValue: boolean;
   value: any;
   _teardownFenceCallback: (value?: unknown) => void;
   _tearDownComplete: Promise<void>;
@@ -110,14 +104,23 @@ class Fixture {
     this.pool = pool;
     this.registration = registration;
     this.usages = new Set();
-    this.hasGeneratorValue = registration.name in parameters;
-    this.value = this.hasGeneratorValue ? parameters[registration.name] : null;
-    if (this.hasGeneratorValue && this.registration.deps.length)
-      throw errorWithCallLocation(`Parameter fixture "${this.registration.name}" should not have dependencies`);
+    this.hasBuiltinValue = false;
+    this.value = null;
+    if (this.pool.builtinValues.has(registration.name)) {
+      this.hasBuiltinValue = true;
+      this.value = this.pool.builtinValues.get(registration.name);
+    } else if (this.pool.parameters.has(registration.name)) {
+      if (this.registration.deps.length)
+        throw errorWithCallLocation(`Parameter fixture "${this.registration.name}" should not have dependencies`);
+      this.hasBuiltinValue = true;
+      // This is a rare case where test does not depend on the parameter,
+      // but some bulitin fixture does.
+      this.value = this.pool.parameters.get(registration.name).values[0];
+    }
   }
 
   async setup() {
-    if (this.hasGeneratorValue)
+    if (this.hasBuiltinValue)
       return;
     const params = {};
     for (const name of this.registration.deps) {
@@ -154,7 +157,7 @@ class Fixture {
   }
 
   async teardown() {
-    if (this.hasGeneratorValue) {
+    if (this.hasBuiltinValue) {
       this.pool.instances.delete(this.registration);
       return;
     }
@@ -181,11 +184,14 @@ export class FixturePool {
   parentPool: FixturePool | undefined;
   instances = new Map<FixtureRegistration, Fixture>();
   registrations: Map<string, FixtureRegistration>;
+  parameters: Map<string, ParameterRegistration>;
+  builtinValues = new Map<string, any>();
 
   constructor(parentPool: FixturePool | undefined) {
     this.parentPool = parentPool;
     this.id = ++lastFixturePoolId;
     this.registrations = new Map(parentPool ? parentPool.registrations : []);
+    this.parameters = new Map(parentPool ? parentPool.parameters : []);
   }
 
   union(other: FixturePool): FixturePool {
@@ -239,11 +245,29 @@ export class FixturePool {
     this.registrations.set(name, registration);
   }
 
-  registerWorkerParameter(parameter: ParameterRegistration) {
-    if (parameterRegistrations.has(parameter.name))
-      throw errorWithCallLocation(`Parameter "${parameter.name}" has been already registered`);
-    parameterRegistrations.set(parameter.name, parameter);
-    matrix[parameter.name] = [parameter.defaultValue];
+  setBulitinValue(name: string, value: any) {
+    this.builtinValues.set(name, value);
+  }
+
+  registerParameter(name: string, values: any[], description?: string) {
+    if (this.parameters.has(name))
+      throw errorWithCallLocation(`Parameter "${name}" has been already registered`);
+    if (description) {
+      const type = typeof values[0];
+      if (type !== 'string' && type !== 'number' && type !== 'boolean')
+        throw errorWithCallLocation(`Only string, number or boolean parameters may have a description`);
+      if (globalParameterDescriptions.has(name))
+        throw errorWithCallLocation(`Parameter "${name}" has been already registered`);
+      globalParameterDescriptions.set(name, { name, description, type });
+    }
+    this.parameters.set(name, { name, values });
+  }
+
+  overrideParameter(name: string, values: any[]) {
+    const registration = this.parameters.get(name);
+    if (!registration)
+      throw errorWithCallLocation(`Parameter "${name}" has not been registered yet. Use 'init' instead.`);
+    this.parameters.set(name, { ...registration, values });
   }
 
   validate() {
@@ -276,7 +300,7 @@ export class FixturePool {
   parametersForFunction(fn: Function, prefix: string, allowTestFixtures: boolean): string[] {
     const result = new Set<string>();
     const visit = (registration: FixtureRegistration) => {
-      if (parameterRegistrations.has(registration.name))
+      if (this.parameters.has(registration.name))
         result.add(registration.name);
       for (const name of registration.deps)
         visit(this._resolveDependency(registration, name)!);

--- a/src/spec.ts
+++ b/src/spec.ts
@@ -15,7 +15,7 @@
  */
 
 import { expect } from './expect';
-import { FixturePool, setParameterValues } from './fixtures';
+import { FixturePool } from './fixtures';
 import { TestModifier } from './testModifier';
 import { errorWithCallLocation } from './util';
 
@@ -106,10 +106,6 @@ export class FolioImpl<TestFixtures = {}, WorkerFixtures = {}, WorkerParameters 
   extend<T = {}, W = {}, P = {}>(): Fixtures<TestFixtures, WorkerFixtures, WorkerParameters, T, W, P> {
     return new Proxy(new FixturesImpl(new FixturePool(this._pool)), proxyHandler) as any;
   }
-
-  generateParametrizedTests<T extends keyof WorkerParameters>(name: T, values: WorkerParameters[T][]) {
-    setParameterValues(name as string, values);
-  }
 }
 
 type FixtureOptions = {
@@ -128,7 +124,10 @@ type WorkerFixtureOptions = {
 };
 
 type WorkerParameterInitializer<R> = {
-  initParameter(description: string, defaultValue: R): void;
+  init(values: R[], description?: string): void;
+};
+type WorkerParameterOverrider<R> = {
+  override(values: R[]): void;
 };
 type WorkerFixtureInitializer<PW, R> = {
   init(fixture: (params: PW, runTest: (value: R) => Promise<void>) => Promise<void>, options: WorkerFixtureOptions): void;
@@ -149,6 +148,8 @@ type Fixtures<TestFixtures, WorkerFixtures, WorkerParameters, T, W, P> = {
   [X in keyof W]: WorkerFixtureInitializer<WorkerParameters & P & WorkerFixtures & W, W[X]>;
 } & {
   [X in keyof T]: TestFixtureInitializer<WorkerParameters & P & WorkerFixtures & W & TestFixtures & T, T[X]>;
+} & {
+  [X in keyof WorkerParameters]: WorkerParameterOverrider<WorkerParameters[X]>;
 } & {
   [X in keyof WorkerFixtures]: WorkerFixtureOverrider<WorkerParameters & P & WorkerFixtures & W, WorkerFixtures[X]>;
 } &  {
@@ -178,15 +179,17 @@ class FixturesImpl<TestFixtures, WorkerFixtures, WorkerParameters, T, W, P> {
     this._pool.overrideFixture(name as string, fixture as any);
   }
 
-  _initParameter<N extends keyof P>(name: N, description: string, defaultValue: P[N]): void {
+  _initParameter(name: string, values: any[], description?: string): void {
     if (this._finished)
       throw errorWithCallLocation(`Should not modify fixtures after build()`);
-    this._pool.registerFixture(name as string, 'worker', async ({}, runTest) => runTest(defaultValue), false);
-    this._pool.registerWorkerParameter({
-      name: name as string,
-      description,
-      defaultValue: defaultValue as any,
-    });
+    this._pool.registerFixture(name as string, 'worker', async ({}, runTest) => runTest(), false);
+    this._pool.registerParameter(name as string, values, description);
+  }
+
+  _overrideParameter(name: string, values: any[]): void {
+    if (this._finished)
+      throw errorWithCallLocation(`Should not modify fixtures after build()`);
+    this._pool.overrideParameter(name as string, values);
   }
 
   build(): Folio<TestFixtures & T, WorkerFixtures & W, WorkerParameters & P> {
@@ -205,9 +208,18 @@ const proxyHandler: ProxyHandler<FixturesImpl<any, any, any, any, any, any>> = {
     if (typeof prop !== 'string' || prop === 'then')
       return undefined;
     return {
-      initParameter: (description, defaultValue) => target._initParameter(prop as any, description, defaultValue),
-      init: (fn, options) => target._init(prop as any, fn, options),
-      override: fn => target._override(prop as any, fn),
+      init: (fnOrValues, optionsOrDescription) => {
+        if (typeof fnOrValues === 'function')
+          target._init(prop as any, fnOrValues, optionsOrDescription);
+        else
+          target._initParameter(prop as any, fnOrValues, optionsOrDescription);
+      },
+      override: fnOrValues => {
+        if (typeof fnOrValues === 'function')
+          target._override(prop as any, fnOrValues);
+        else
+          target._overrideParameter(prop as any, fnOrValues);
+      },
     };
   },
 };

--- a/test/assets/register-parameter.ts
+++ b/test/assets/register-parameter.ts
@@ -17,8 +17,8 @@
 import { folio as baseFolio } from '../..';
 
 const builder = baseFolio.extend<{ fixture1: string, fixture2: string }, {}, { param1: string, param2: string }>();
-builder.param1.initParameter('Custom parameter 1', '');
-builder.param2.initParameter('Custom parameter 2', 'value2');
+builder.param1.init([''], 'Custom parameter 1');
+builder.param2.init(['value2'], 'Custom parameter 2');
 builder.fixture1.init(async ({testInfo}, runTest) => {
   await runTest(testInfo.parameters.param1 as string);
 });

--- a/test/fixtures.spec.ts
+++ b/test/fixtures.spec.ts
@@ -295,7 +295,7 @@ it('should teardown fixtures after timeout', async ({ runInlineFixturesTest, tes
   const result = await runInlineFixturesTest({
     'a.spec.ts': `
       const builder = baseFolio.extend();
-      builder.file.initParameter('File', '');
+      builder.file.init([''], 'File');
       builder.t.init(async ({ file }, runTest) => {
         await runTest('t');
         require('fs').appendFileSync(file, 'test fixture teardown\\n', 'utf8');
@@ -380,13 +380,12 @@ it('should understand parameters in overrides calling base', async ({ runInlineF
   const result = await runInlineFixturesTest({
     'a.test.js': `
       const builder = baseFolio.extend();
-      builder.param.initParameter('Param', 'param');
+      builder.param.init(['p1', 'p2', 'p3'], 'Param');
       builder.foo.init(async ({}, test) => await test('foo'));
       builder.bar.init(async ({foo}, test) => await test(foo + '-bar'));
       builder.foo.override(async ({ foo, param }, test) => await test(foo + '-' + param));
       builder.foo.override(async ({ foo }, test) => await test(foo + '-override'));
       const fixtures = builder.build();
-      fixtures.generateParametrizedTests('param', ['p1', 'p2', 'p3']);
       fixtures.it('test', async ({ bar }) => {
         console.log(bar);
       });

--- a/test/list-mode.spec.ts
+++ b/test/list-mode.spec.ts
@@ -21,9 +21,8 @@ it('should work with parameters', async ({ runInlineFixturesTest }) => {
   const result = await runInlineFixturesTest({
     'fixtures.js': `
       const builder = baseFolio.extend();
-      builder.worker.initParameter('', '');
+      builder.worker.init(['A', 'B', 'C'], '');
       const fixtures = builder.build();
-      fixtures.generateParametrizedTests('worker', ['A', 'B', 'C']);
       module.exports = fixtures;
     `,
     'a.test.js': `

--- a/test/parameters.spec.ts
+++ b/test/parameters.spec.ts
@@ -21,11 +21,9 @@ it('should run with each configuration', async ({ runInlineFixturesTest }) => {
   const result = await runInlineFixturesTest({
     'a.test.ts': `
       const builder = baseFolio.extend();
-      builder.foo.initParameter('Foo parameters', 'foo');
-      builder.bar.initParameter('Bar parameters', 'bar');
+      builder.foo.init(['foo1', 'foo2', 'foo3'], 'Foo parameters');
+      builder.bar.init(['bar1', 'bar2'], 'Bar parameters');
       const folio = builder.build();
-      folio.generateParametrizedTests('foo', ['foo1', 'foo2', 'foo3']);
-      folio.generateParametrizedTests('bar', ['bar1', 'bar2']);
 
       const { it } = folio;
 
@@ -51,28 +49,14 @@ it('should run with each configuration', async ({ runInlineFixturesTest }) => {
   }
 });
 
-it('should fail on invalid parameters', async ({ runInlineTest }) => {
-  const result = await runInlineTest({
-    'a.spec.ts': `
-      folio.generateParametrizedTests('invalid', ['value']);
-
-      it('success', async ({}) => {
-      });
-    `
-  });
-  expect(result.exitCode).toBe(1);
-  expect(result.output).toContain('a.spec.ts');
-  expect(result.output).toContain(`Unregistered parameter 'invalid' was set.`);
-});
-
 it('should throw on duplicate parameters globally', async ({ runInlineFixturesTest }) => {
   const result = await runInlineFixturesTest({
     'a.spec.ts': `
       const builder1 = baseFolio.extend();
-      builder1.foo.initParameter('Foo', '');
+      builder1.foo.init([''], 'Foo');
       const f1 = builder1.build();
       const builder2 = baseFolio.extend();
-      builder2.foo.initParameter('Bar', '123');
+      builder2.foo.init(['123'], 'Bar');
       const f2 = builder2.build();
       f1.it('success', async ({}) => {
       });
@@ -89,7 +73,7 @@ it('should use kebab for CLI name', async ({ runInlineFixturesTest }) => {
   const result = await runInlineFixturesTest({
     'a.test.ts': `
       const builder = baseFolio.extend();
-      builder.fooCamelCase.initParameter('Foo parameters', 'foo');
+      builder.fooCamelCase.init(['foo'], 'Foo parameters');
       const folio = builder.build();
 
       const { it } = folio;
@@ -106,13 +90,13 @@ it('should show parameters descriptions', async ({ runInlineFixturesTest }) => {
   const result = await runInlineFixturesTest({
     'a.test.ts': `
       const builder = baseFolio.extend();
-      builder.browserName.initParameter('Browser name', 'chromium');
-      builder.headful.initParameter('Whether to show browser window or not', false);
+      builder.browserName.init(['chromium'], 'Browser name');
+      builder.headful.init([false], 'Whether to show browser window or not');
       const folio = builder.build();
     `
   }, { 'help': true });
   expect(result.output).toContain(`-p, --param browserName=<value>`);
-  expect(result.output).toContain(`Browser name (default: "chromium")`);
+  expect(result.output).toContain(`Browser name`);
   expect(result.output).toContain(`-p, --param headful`);
   expect(result.output).toContain(`Whether to show browser window or not`);
 
@@ -123,7 +107,7 @@ it('should support integer parameter', async ({ runInlineFixturesTest }) => {
   const result = await runInlineFixturesTest({
     'a.test.ts': `
       const builder = baseFolio.extend();
-      builder.integer.initParameter('Some integer', 5);
+      builder.integer.init([5], 'Some integer');
       const folio = builder.build();
       const { it } = folio;
       it('success', async ({integer}) => {
@@ -138,7 +122,7 @@ it('should support boolean parameter', async ({ runInlineFixturesTest }) => {
   const result = await runInlineFixturesTest({
     'a.test.ts': `
       const builder = baseFolio.extend();
-      builder.bool.initParameter('Some bool', false);
+      builder.bool.init([false], 'Some bool');
       const folio = builder.build();
       const { it } = folio;
       it('success', async ({bool}) => {
@@ -153,7 +137,7 @@ it('should generate tests from CLI', async ({ runInlineFixturesTest }) => {
   const result = await runInlineFixturesTest({
     'a.test.ts': `
       const builder = baseFolio.extend();
-      builder.bool.initParameter('Some bool', false);
+      builder.bool.init([false], 'Some bool');
       const folio = builder.build();
       const { it } = folio;
       it('success', async ({bool}) => {
@@ -171,7 +155,7 @@ it('tests respect automatic fixture parameters', async ({ runInlineFixturesTest 
   const result = await runInlineFixturesTest({
     'a.test.js': `
       const builder = baseFolio.extend();
-      builder.param.initParameter('Some param', 'value');
+      builder.param.init(['value'], 'Some param');
       builder.automaticTestFixture.init(async ({param}, runTest) => {
         await runTest(param);
       }, { auto: true });
@@ -189,7 +173,7 @@ it('testParametersPathSegment does not throw in non-parametrized test', async ({
   const result = await runInlineFixturesTest({
     'a.test.js': `
       const builder = baseFolio.extend();
-      builder.param.initParameter('Some param', 'value');
+      builder.param.init(['value'], 'Some param');
       builder.testParametersPathSegment.override(async ({ param }, runTest) => {
         await runTest(param);
       });
@@ -211,11 +195,10 @@ it('should not duplicate parameters in configuration', async ({ runInlineFixture
   const result = await runInlineFixturesTest({
     'a.test.ts': `
       const builder = baseFolio.extend();
-      builder.foo.initParameter('Foo', 'foo');
+      builder.foo.init(['foo1', 'foo2', 'foo3'], 'Foo');
       builder.f1.init(async({foo}, runTest) => runTest(foo));
       builder.f2.init(async({foo}, runTest) => runTest(foo));
       const folio = builder.build();
-      folio.generateParametrizedTests('foo', ['foo1', 'foo2', 'foo3']);
 
       const { it } = folio;
 
@@ -232,4 +215,41 @@ it('should not duplicate parameters in configuration', async ({ runInlineFixture
   expect(result.passed).toBe(3);
   const outputs = result.results.map(r => r.stdout[0].text.replace(/\s/g, ''));
   expect(outputs.sort()).toEqual(['foo1:foo1', 'foo2:foo2', 'foo3:foo3']);
+});
+
+it('should use different parameter values in different folios', async ({ runInlineFixturesTest }) => {
+  const result = await runInlineFixturesTest({
+    'a.test.ts': `
+      const builder = baseFolio.extend();
+      builder.foo.init(['foo1', 'foo2', 'foo3'], 'Foo');
+      const base = builder.build();
+
+      const builder1 = base.extend();
+      builder1.foo.override(['bar1', 'bar2']);
+      const folio1 = builder1.build();
+
+      const builder2 = base.extend();
+      builder2.foo.override(['baz1']);
+      const folio2 = builder2.build();
+
+      base.it('runs 3 times', async ({ foo }) => {
+        console.log('base:' + foo);
+      });
+      folio1.it('runs 2 times', async ({ foo }) => {
+        console.log('folio1:' + foo);
+      });
+      folio2.it('runs 1 time', async ({ foo }) => {
+        console.log('folio2:' + foo);
+      });
+    `
+  });
+
+  expect(result.exitCode).toBe(0);
+  expect(result.passed).toBe(6);
+  const outputs = result.results.map(r => r.stdout[0].text.replace(/\s/g, ''));
+  expect(outputs.sort()).toEqual([
+    'base:foo1', 'base:foo2', 'base:foo3',
+    'folio1:bar1', 'folio1:bar2',
+    'folio2:baz1',
+  ]);
 });

--- a/test/worker-index.spec.ts
+++ b/test/worker-index.spec.ts
@@ -72,7 +72,7 @@ it('should not reuse worker for different parameters', async ({ runInlineFixture
   const result = await runInlineFixturesTest({
     'a.test.js': `
       const builder = baseFolio.extend();
-      builder.param.initParameter('', '');
+      builder.param.init([''], '');
       builder.worker2.init(({}, runTest) => runTest(), { scope: 'worker' });
       const { it } = builder.build();
 


### PR DESCRIPTION
This way, you can have two folios that use the same parameter but different values, e.g. a set of tests for webkit only, and a set of tests for three browsers.

This also changes the api to define parameters:
```ts
fixtures.param.init([value1, value2], 'Description');
fixtures.param.override([value3]);
```