### PR TITLE
chore: use type for spec argument

### DIFF
--- a/src/runnerSpec.ts
+++ b/src/runnerSpec.ts
@@ -17,14 +17,14 @@
 import { installTransform } from './transform';
 import { RunnerSuite, RunnerSpec } from './runnerTest';
 import { callLocation, errorWithCallLocation } from './util';
-import { FolioImpl, setImplementation } from './spec';
+import { FolioImpl, setImplementation, SpecType } from './spec';
 import { TestModifier } from './testModifier';
 import { Config } from './config';
 
 export function runnerSpec(suite: RunnerSuite, config: Config): () => void {
   const suites = [suite];
 
-  const it = (spec: 'default' | 'skip' | 'only', folio: FolioImpl, title: string, modifierFn: (modifier: TestModifier, parameters: any) => void | Function, fn?: Function) => {
+  const it = (spec: SpecType, folio: FolioImpl, title: string, modifierFn: (modifier: TestModifier, parameters: any) => void | Function, fn?: Function) => {
     const suite = suites[0];
     if (typeof fn !== 'function') {
       fn = modifierFn;
@@ -48,7 +48,7 @@ export function runnerSpec(suite: RunnerSuite, config: Config): () => void {
     return test;
   };
 
-  const describe = (spec: 'default' | 'skip' | 'only', folio: FolioImpl, title: string, modifierFn: (suite: TestModifier, parameters: any) => void | Function, fn?: Function) => {
+  const describe = (spec: SpecType, folio: FolioImpl, title: string, modifierFn: (suite: TestModifier, parameters: any) => void | Function, fn?: Function) => {
     if (typeof fn !== 'function') {
       fn = modifierFn;
       modifierFn = null;

--- a/src/spec.ts
+++ b/src/spec.ts
@@ -21,9 +21,11 @@ import { errorWithCallLocation } from './util';
 
 Error.stackTraceLimit = 15;
 
+export type SpecType = 'default' | 'skip' | 'only';
+
 export type Implementation = {
-  it: (spec: 'default' | 'skip' | 'only', folio: FolioImpl, ...args: any[]) => void;
-  describe: (spec: 'default' | 'skip' | 'only', folio: FolioImpl, ...args: any[]) => void;
+  it: (spec: SpecType, folio: FolioImpl, ...args: any[]) => void;
+  describe: (spec: SpecType, folio: FolioImpl, ...args: any[]) => void;
   beforeEach: (folio: FolioImpl, fn: Function) => void;
   afterEach: (folio: FolioImpl, fn: Function) => void;
   beforeAll: (folio: FolioImpl, fn: Function) => void;

--- a/src/workerSpec.ts
+++ b/src/workerSpec.ts
@@ -17,7 +17,7 @@
 import { WorkerSpec, WorkerSuite } from './workerTest';
 import { installTransform } from './transform';
 import { callLocation } from './util';
-import { FolioImpl, setImplementation } from './spec';
+import { FolioImpl, setImplementation, SpecType } from './spec';
 import { TestModifier } from './testModifier';
 
 let currentRunSuites: WorkerSuite[];
@@ -26,7 +26,7 @@ export function workerSpec(suite: WorkerSuite): () => void {
   const suites = [suite];
   currentRunSuites = suites;
 
-  const it = (spec: 'default' | 'skip' | 'only', folio: FolioImpl, title: string, modifierFn: (modifier: TestModifier, parameters: any) => void | Function, fn?: Function) => {
+  const it = (spec: SpecType, folio: FolioImpl, title: string, modifierFn: (modifier: TestModifier, parameters: any) => void | Function, fn?: Function) => {
     fn = fn || modifierFn;
     const test = new WorkerSpec(folio, title, fn, suites[0]);
     test.file = suite.file;
@@ -34,7 +34,7 @@ export function workerSpec(suite: WorkerSuite): () => void {
     return test;
   };
 
-  const describe = (spec: 'default' | 'skip' | 'only', folio: FolioImpl, title: string, modifierFn: (modifier: TestModifier, parameters: any) => void | Function, fn?: Function) => {
+  const describe = (spec: SpecType, folio: FolioImpl, title: string, modifierFn: (modifier: TestModifier, parameters: any) => void | Function, fn?: Function) => {
     fn = fn || modifierFn;
     const child = new WorkerSuite(folio, title, suites[0]);
     child.file = suite.file;


### PR DESCRIPTION
introduce a type for `'default' | 'skip' | 'only'`