### PR TITLE
feat(json): always serialize paths as posix-paths in json report

### DIFF
--- a/src/fixtures.ts
+++ b/src/fixtures.ts
@@ -35,7 +35,8 @@ export type TestInfo = {
   // Declaration
   title: string;
   file: string;
-  location: string;
+  line: number;
+  column: number;
   fn: Function;
 
   // Parameters

--- a/src/fixtures.ts
+++ b/src/fixtures.ts
@@ -35,11 +35,8 @@ export type TestInfo = {
   // Declaration
   title: string;
   file: string;
-  location?: {
-    file: string,
-    line: number,
-    column: number,
-  },
+  line: number;
+  column: number;
   fn: Function;
 
   // Parameters

--- a/src/fixtures.ts
+++ b/src/fixtures.ts
@@ -35,8 +35,11 @@ export type TestInfo = {
   // Declaration
   title: string;
   file: string;
-  line: number;
-  column: number;
+  location?: {
+    file: string,
+    line: number,
+    column: number,
+  },
   fn: Function;
 
   // Parameters

--- a/src/reporters/base.ts
+++ b/src/reporters/base.ts
@@ -161,8 +161,8 @@ function formatTestHeader(config: Config, test: Test, index?: number): string {
   const tokens: string[] = [];
   const spec = test.spec;
   let relativePath = path.relative(config.testDir, spec.file) || path.basename(spec.file);
-  if (spec.location.includes(spec.file))
-    relativePath += spec.location.substring(spec.file.length);
+  if (spec.line && spec.column)
+    relativePath += ':' + spec.line + ':' + spec.column;
   const passedUnexpectedlySuffix = test.results[0].status === 'passed' ? ' -- passed unexpectedly' : '';
   const header = `  ${index ? index + ')' : ''} ${relativePath} › ${spec.fullTitle()}${passedUnexpectedlySuffix}`;
   tokens.push(colors.bold(colors.red(pad(header, '='))));

--- a/src/reporters/base.ts
+++ b/src/reporters/base.ts
@@ -161,8 +161,8 @@ function formatTestHeader(config: Config, test: Test, index?: number): string {
   const tokens: string[] = [];
   const spec = test.spec;
   let relativePath = path.relative(config.testDir, spec.file) || path.basename(spec.file);
-  if (spec.line && spec.column)
-    relativePath += ':' + spec.line + ':' + spec.column;
+  if (spec.location && spec.location.file === spec.file)
+    relativePath += ':' + spec.location.line + ':' + spec.location.column;
   const passedUnexpectedlySuffix = test.results[0].status === 'passed' ? ' -- passed unexpectedly' : '';
   const header = `  ${index ? index + ')' : ''} ${relativePath} › ${spec.fullTitle()}${passedUnexpectedlySuffix}`;
   tokens.push(colors.bold(colors.red(pad(header, '='))));

--- a/src/reporters/base.ts
+++ b/src/reporters/base.ts
@@ -161,8 +161,7 @@ function formatTestHeader(config: Config, test: Test, index?: number): string {
   const tokens: string[] = [];
   const spec = test.spec;
   let relativePath = path.relative(config.testDir, spec.file) || path.basename(spec.file);
-  if (spec.location && spec.location.file === spec.file)
-    relativePath += ':' + spec.location.line + ':' + spec.location.column;
+  relativePath += ':' + spec.line + ':' + spec.column;
   const passedUnexpectedlySuffix = test.results[0].status === 'passed' ? ' -- passed unexpectedly' : '';
   const header = `  ${index ? index + ')' : ''} ${relativePath} › ${spec.fullTitle()}${passedUnexpectedlySuffix}`;
   tokens.push(colors.bold(colors.red(pad(header, '='))));

--- a/src/reporters/json.ts
+++ b/src/reporters/json.ts
@@ -15,7 +15,6 @@
  */
 
 import fs from 'fs';
-import url from 'url';
 import path from 'path';
 import { Config } from '../config';
 import { EmptyReporter } from '../reporter';
@@ -36,6 +35,10 @@ export type ReportFormat = {
   errors?: { error: TestError }[];
   suites?: SerializedSuite[];
 };
+
+function toPosixPath(aPath: string): string {
+  return aPath.split(path.sep).join(path.posix.sep);
+}
 
 class JSONReporter extends EmptyReporter {
   config: Config;
@@ -59,8 +62,8 @@ class JSONReporter extends EmptyReporter {
     outputReport({
       config: {
         ...this.config,
-        outputDir: url.pathToFileURL(this.config.outputDir).toString(),
-        testDir: url.pathToFileURL(this.config.testDir).toString(),
+        outputDir: toPosixPath(this.config.outputDir),
+        testDir: toPosixPath(this.config.testDir),
       },
       suites: this.suite.suites.map(suite => this._serializeSuite(suite)).filter(s => s),
       errors: this._errors
@@ -73,7 +76,7 @@ class JSONReporter extends EmptyReporter {
     const suites = suite.suites.map(suite => this._serializeSuite(suite)).filter(s => s);
     return {
       title: suite.title,
-      file: url.pathToFileURL(suite.file).toString(),
+      file: toPosixPath(path.relative(this.config.testDir, suite.file)),
       line: suite.line,
       column: suite.column,
       specs: suite.specs.map(test => this._serializeTestSpec(test)),
@@ -84,7 +87,7 @@ class JSONReporter extends EmptyReporter {
   private _serializeTestSpec(spec: Spec) {
     return {
       title: spec.title,
-      file: url.pathToFileURL(spec.file).toString(),
+      file: toPosixPath(path.relative(this.config.testDir, spec.file)),
       line: spec.line,
       column: spec.column,
       tests: spec.tests.map(r => this._serializeTest(r))

--- a/src/reporters/json.ts
+++ b/src/reporters/json.ts
@@ -23,11 +23,8 @@ import { Test, Suite, Spec, TestResult, TestError } from '../test';
 export interface SerializedSuite {
   title: string;
   file: string;
-  location?: {
-    line: number;
-    column: number;
-    file: string;
-  };
+  column: number;
+  line: number;
   specs: ReturnType<JSONReporter['_serializeTestSpec']>[];
   suites?: SerializedSuite[];
 }
@@ -79,12 +76,9 @@ class JSONReporter extends EmptyReporter {
     const suites = suite.suites.map(suite => this._serializeSuite(suite)).filter(s => s);
     return {
       title: suite.title,
-      file: suite.file,
-      location: suite.location ? {
-        file: toPosixPath(path.relative(this.config.testDir, suite.location.file)),
-        line: suite.location.line,
-        column: suite.location.column,
-      } : undefined,
+      file: toPosixPath(path.relative(this.config.testDir, suite.file)),
+      line: suite.line,
+      column: suite.column,
       specs: suite.specs.map(test => this._serializeTestSpec(test)),
       suites: suites.length ? suites : undefined,
     };
@@ -94,12 +88,9 @@ class JSONReporter extends EmptyReporter {
     return {
       title: spec.title,
       tests: spec.tests.map(r => this._serializeTest(r)),
-      file: spec.file,
-      location: spec.location ? {
-        file: toPosixPath(path.relative(this.config.testDir, spec.location.file)),
-        line: spec.location.line,
-        column: spec.location.column,
-      } : undefined,
+      file: toPosixPath(path.relative(this.config.testDir, spec.file)),
+      line: spec.line,
+      column: spec.column,
     };
   }
 

--- a/src/reporters/json.ts
+++ b/src/reporters/json.ts
@@ -23,8 +23,11 @@ import { Test, Suite, Spec, TestResult, TestError } from '../test';
 export interface SerializedSuite {
   title: string;
   file: string;
-  line: (number|undefined);
-  column: (number|undefined);
+  location?: {
+    line: number;
+    column: number;
+    file: string;
+  };
   specs: ReturnType<JSONReporter['_serializeTestSpec']>[];
   suites?: SerializedSuite[];
 }
@@ -76,9 +79,12 @@ class JSONReporter extends EmptyReporter {
     const suites = suite.suites.map(suite => this._serializeSuite(suite)).filter(s => s);
     return {
       title: suite.title,
-      file: toPosixPath(path.relative(this.config.testDir, suite.file)),
-      line: suite.line,
-      column: suite.column,
+      file: suite.file,
+      location: suite.location ? {
+        file: toPosixPath(path.relative(this.config.testDir, suite.location.file)),
+        line: suite.location.line,
+        column: suite.location.column,
+      } : undefined,
       specs: suite.specs.map(test => this._serializeTestSpec(test)),
       suites: suites.length ? suites : undefined,
     };
@@ -87,10 +93,13 @@ class JSONReporter extends EmptyReporter {
   private _serializeTestSpec(spec: Spec) {
     return {
       title: spec.title,
-      file: toPosixPath(path.relative(this.config.testDir, spec.file)),
-      line: spec.line,
-      column: spec.column,
-      tests: spec.tests.map(r => this._serializeTest(r))
+      tests: spec.tests.map(r => this._serializeTest(r)),
+      file: spec.file,
+      location: spec.location ? {
+        file: toPosixPath(path.relative(this.config.testDir, spec.location.file)),
+        line: spec.location.line,
+        column: spec.location.column,
+      } : undefined,
     };
   }
 

--- a/src/reporters/junit.ts
+++ b/src/reporters/junit.ts
@@ -131,7 +131,7 @@ class JUnitReporter extends EmptyReporter {
       entry.children.push({
         name: 'failure',
         attributes: {
-          message: `${path.basename(test.spec.file)}${test.spec.line}${test.spec.column} ${test.spec.title}`,
+          message: `${path.basename(test.spec.file)}:${test.spec.line}:${test.spec.column} ${test.spec.title}`,
           type: 'FAILURE',
         },
         text: stripAscii(formatFailure(this.config, test))

--- a/src/reporters/junit.ts
+++ b/src/reporters/junit.ts
@@ -131,7 +131,7 @@ class JUnitReporter extends EmptyReporter {
       entry.children.push({
         name: 'failure',
         attributes: {
-          message: `${path.basename(test.spec.location.file)}:${test.spec.location.line}:${test.spec.location.column} ${test.spec.title}`,
+          message: `${path.basename(test.spec.file)}:${test.spec.line}:${test.spec.column} ${test.spec.title}`,
           type: 'FAILURE',
         },
         text: stripAscii(formatFailure(this.config, test))

--- a/src/reporters/junit.ts
+++ b/src/reporters/junit.ts
@@ -131,7 +131,7 @@ class JUnitReporter extends EmptyReporter {
       entry.children.push({
         name: 'failure',
         attributes: {
-          message: `${path.basename(test.spec.location)} ${test.spec.title}`,
+          message: `${path.basename(test.spec.file)}${test.spec.line}${test.spec.column} ${test.spec.title}`,
           type: 'FAILURE',
         },
         text: stripAscii(formatFailure(this.config, test))

--- a/src/reporters/junit.ts
+++ b/src/reporters/junit.ts
@@ -131,7 +131,7 @@ class JUnitReporter extends EmptyReporter {
       entry.children.push({
         name: 'failure',
         attributes: {
-          message: `${path.basename(test.spec.file)}:${test.spec.line}:${test.spec.column} ${test.spec.title}`,
+          message: `${path.basename(test.spec.location.file)}:${test.spec.location.line}:${test.spec.location.column} ${test.spec.title}`,
           type: 'FAILURE',
         },
         text: stripAscii(formatFailure(this.config, test))

--- a/src/runnerSpec.ts
+++ b/src/runnerSpec.ts
@@ -33,11 +33,7 @@ export function runnerSpec(suite: RunnerSuite, config: Config): () => void {
     const test = new RunnerSpec(folio, title, fn, suite);
     test._usedParameters = folio._pool.parametersForFunction(fn, `Test`, true);
     test.file = suite.file;
-    const location = callLocation();
-    if (location) {
-      test.line = location.line;
-      test.column = location.column;
-    }
+    test.location = callLocation();
     if (spec === 'only')
       test._only = true;
 
@@ -58,12 +54,8 @@ export function runnerSpec(suite: RunnerSuite, config: Config): () => void {
       modifierFn = null;
     }
     const child = new RunnerSuite(folio, title, suites[0]);
-    const location = callLocation();
+    child.location = callLocation();
     child.file = suite.file;
-    if (location) {
-      child.line = location.line;
-      child.column = location.column;
-    }
     if (spec === 'only')
       child._only = true;
 

--- a/src/runnerSpec.ts
+++ b/src/runnerSpec.ts
@@ -32,8 +32,10 @@ export function runnerSpec(suite: RunnerSuite, config: Config): () => void {
     }
     const test = new RunnerSpec(folio, title, fn, suite);
     test._usedParameters = folio._pool.parametersForFunction(fn, `Test`, true);
-    test.file = suite.file;
-    test.location = callLocation();
+    const location = callLocation(suite.file);
+    test.file = location.file;
+    test.line = location.line;
+    test.column = location.column;
     if (spec === 'only')
       test._only = true;
 
@@ -54,8 +56,10 @@ export function runnerSpec(suite: RunnerSuite, config: Config): () => void {
       modifierFn = null;
     }
     const child = new RunnerSuite(folio, title, suites[0]);
-    child.location = callLocation();
-    child.file = suite.file;
+    const location = callLocation(suite.file);
+    child.file = location.file;
+    child.line = location.line;
+    child.column = location.column;
     if (spec === 'only')
       child._only = true;
 

--- a/src/runnerSpec.ts
+++ b/src/runnerSpec.ts
@@ -33,7 +33,11 @@ export function runnerSpec(suite: RunnerSuite, config: Config): () => void {
     const test = new RunnerSpec(folio, title, fn, suite);
     test._usedParameters = folio._pool.parametersForFunction(fn, `Test`, true);
     test.file = suite.file;
-    test.location = callLocation();
+    const location = callLocation();
+    if (location) {
+      test.line = location.line;
+      test.column = location.column;
+    }
     if (spec === 'only')
       test._only = true;
 
@@ -54,8 +58,12 @@ export function runnerSpec(suite: RunnerSuite, config: Config): () => void {
       modifierFn = null;
     }
     const child = new RunnerSuite(folio, title, suites[0]);
+    const location = callLocation();
     child.file = suite.file;
-    child.location = callLocation();
+    if (location) {
+      child.line = location.line;
+      child.column = location.column;
+    }
     if (spec === 'only')
       child._only = true;
 

--- a/src/test.ts
+++ b/src/test.ts
@@ -22,11 +22,8 @@ import { errorWithCallLocation } from './util';
 class Base {
   title: string;
   file: string;
-  location?: {
-    file: string,
-    line: number,
-    column: number,
-  };
+  line: number;
+  column: number;
   parent?: Suite;
 
   _only = false;

--- a/src/test.ts
+++ b/src/test.ts
@@ -22,7 +22,8 @@ import { errorWithCallLocation } from './util';
 class Base {
   title: string;
   file: string;
-  location: string;
+  line: number;
+  column: number;
   parent?: Suite;
 
   _only = false;

--- a/src/test.ts
+++ b/src/test.ts
@@ -22,8 +22,11 @@ import { errorWithCallLocation } from './util';
 class Base {
   title: string;
   file: string;
-  line: number;
-  column: number;
+  location?: {
+    file: string,
+    line: number,
+    column: number,
+  };
   parent?: Suite;
 
   _only = false;

--- a/src/util.ts
+++ b/src/util.ts
@@ -78,12 +78,16 @@ function callFrames(): string[] {
   return frames;
 }
 
-export function callLocation(): string {
+export function callLocation(): ({file: string, line: number, column: number}|undefined) {
   const frames = callFrames();
   if (!frames.length)
-    return '';
+    return undefined;
   const location = stackUtils.parseLine(frames[0]);
-  return `${path.resolve(cwd, location.file)}:${location.line}:${location.column}`;
+  return {
+    file: path.resolve(cwd, location.file),
+    line: location.line,
+    column: location.column,
+  };
 }
 
 export function errorWithCallLocation(message: string): Error {

--- a/src/util.ts
+++ b/src/util.ts
@@ -78,10 +78,10 @@ function callFrames(): string[] {
   return frames;
 }
 
-export function callLocation(): ({file: string, line: number, column: number}|undefined) {
+export function callLocation(fallbackFile: string): {file: string, line: number, column: number} {
   const frames = callFrames();
   if (!frames.length)
-    return undefined;
+    return {file: fallbackFile, line: 1, column: 1};
   const location = stackUtils.parseLine(frames[0]);
   return {
     file: path.resolve(cwd, location.file),

--- a/src/workerRunner.ts
+++ b/src/workerRunner.ts
@@ -136,7 +136,8 @@ export class WorkerRunner extends EventEmitter {
     this._setCurrentTestInfo({
       title: test.title,
       file: test.file,
-      location: test.location,
+      line: test.line,
+      column: test.column,
       fn: test.fn,
       parameters,
       repeatEachIndex: this._repeatEachIndex,

--- a/src/workerRunner.ts
+++ b/src/workerRunner.ts
@@ -136,8 +136,7 @@ export class WorkerRunner extends EventEmitter {
     this._setCurrentTestInfo({
       title: test.title,
       file: test.file,
-      line: test.line,
-      column: test.column,
+      location: test.location,
       fn: test.fn,
       parameters,
       repeatEachIndex: this._repeatEachIndex,

--- a/src/workerSpec.ts
+++ b/src/workerSpec.ts
@@ -30,7 +30,11 @@ export function workerSpec(suite: WorkerSuite): () => void {
     fn = fn || modifierFn;
     const test = new WorkerSpec(folio, title, fn, suites[0]);
     test.file = suite.file;
-    test.location = callLocation();
+    const location = callLocation();
+    if (location) {
+      test.line = location.line;
+      test.column = location.column;
+    }
     return test;
   };
 
@@ -38,7 +42,11 @@ export function workerSpec(suite: WorkerSuite): () => void {
     fn = fn || modifierFn;
     const child = new WorkerSuite(folio, title, suites[0]);
     child.file = suite.file;
-    child.location = callLocation();
+    const location = callLocation();
+    if (location) {
+      child.line = location.line;
+      child.column = location.column;
+    }
     suites.unshift(child);
     fn();
     suites.shift();

--- a/src/workerSpec.ts
+++ b/src/workerSpec.ts
@@ -29,16 +29,20 @@ export function workerSpec(suite: WorkerSuite): () => void {
   const it = (spec: SpecType, folio: FolioImpl, title: string, modifierFn: (modifier: TestModifier, parameters: any) => void | Function, fn?: Function) => {
     fn = fn || modifierFn;
     const test = new WorkerSpec(folio, title, fn, suites[0]);
-    test.file = suite.file;
-    test.location = callLocation();
+    const location = callLocation(suite.file);
+    test.file = location.file;
+    test.line = location.line;
+    test.column = location.column;
     return test;
   };
 
   const describe = (spec: SpecType, folio: FolioImpl, title: string, modifierFn: (modifier: TestModifier, parameters: any) => void | Function, fn?: Function) => {
     fn = fn || modifierFn;
     const child = new WorkerSuite(folio, title, suites[0]);
-    child.file = suite.file;
-    child.location = callLocation();
+    const location = callLocation(suite.file);
+    child.file = location.file;
+    child.line = location.line;
+    child.column = location.column;
     suites.unshift(child);
     fn();
     suites.shift();

--- a/src/workerSpec.ts
+++ b/src/workerSpec.ts
@@ -30,11 +30,7 @@ export function workerSpec(suite: WorkerSuite): () => void {
     fn = fn || modifierFn;
     const test = new WorkerSpec(folio, title, fn, suites[0]);
     test.file = suite.file;
-    const location = callLocation();
-    if (location) {
-      test.line = location.line;
-      test.column = location.column;
-    }
+    test.location = callLocation();
     return test;
   };
 
@@ -42,11 +38,7 @@ export function workerSpec(suite: WorkerSuite): () => void {
     fn = fn || modifierFn;
     const child = new WorkerSuite(folio, title, suites[0]);
     child.file = suite.file;
-    const location = callLocation();
-    if (location) {
-      child.line = location.line;
-      child.column = location.column;
-    }
+    child.location = callLocation();
     suites.unshift(child);
     fn();
     suites.shift();

--- a/test/list-mode.spec.ts
+++ b/test/list-mode.spec.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import { expect } from 'folio';
+import path from 'path';
 import { folio } from './fixtures';
 const { it } = folio;
 
@@ -86,7 +87,7 @@ it('should emit test annotations', async ({ runInlineTest }) => {
   expect(result.report.suites[0].specs[0].tests[0].annotations).toEqual([{ type: 'fail', description: 'Fail annotation' }]);
 });
 
-it('should have file URLs instead of paths for portability', async ({ runInlineTest }) => {
+it('should have relative always-posix paths', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'a.test.js': `
       it('math works!', async ({}) => {
@@ -95,9 +96,9 @@ it('should have file URLs instead of paths for portability', async ({ runInlineT
     `
   }, { 'list': true });
   expect(result.exitCode).toBe(0);
-  expect(result.report.config.outputDir.startsWith('file://')).toBe(true);
-  expect(result.report.config.testDir.startsWith('file://')).toBe(true);
-  expect(result.report.suites[0].specs[0].file.startsWith('file://')).toBe(true);
+  expect(result.report.config.testDir.indexOf(path.win32.sep)).toBe(-1);
+  expect(result.report.config.outputDir.indexOf(path.win32.sep)).toBe(-1);
+  expect(result.report.suites[0].specs[0].file).toBe('a.test.js');
   expect(result.report.suites[0].specs[0].line).toBe(5);
   expect(result.report.suites[0].specs[0].column).toBe(7);
 });

--- a/test/list-mode.spec.ts
+++ b/test/list-mode.spec.ts
@@ -86,6 +86,22 @@ it('should emit test annotations', async ({ runInlineTest }) => {
   expect(result.report.suites[0].specs[0].tests[0].annotations).toEqual([{ type: 'fail', description: 'Fail annotation' }]);
 });
 
+it('should have file URLs instead of paths for portability', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'a.test.js': `
+      it('math works!', async ({}) => {
+        expect(1 + 1).toBe(2);
+      });
+    `
+  }, { 'list': true });
+  expect(result.exitCode).toBe(0);
+  expect(result.report.config.outputDir.startsWith('file://')).toBe(true);
+  expect(result.report.config.testDir.startsWith('file://')).toBe(true);
+  expect(result.report.suites[0].specs[0].file.startsWith('file://')).toBe(true);
+  expect(result.report.suites[0].specs[0].line).toBe(5);
+  expect(result.report.suites[0].specs[0].column).toBe(7);
+});
+
 it('should emit suite annotations', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'a.test.js': `


### PR DESCRIPTION
This patch:
- starts serializing all paths as posix-paths to aid json report portability
- saves file location for specs relative to `config.testDir`
- starts storing `line` and `column` for specs explicitly instead of a
  `location` string. This reduces report size and simplifies later
  processing.