### PR TITLE
feat(json): export `spec.ok()` in the JSON reporter.

### DIFF
--- a/src/reporters/json.ts
+++ b/src/reporters/json.ts
@@ -87,6 +87,7 @@ class JSONReporter extends EmptyReporter {
   private _serializeTestSpec(spec: Spec) {
     return {
       title: spec.title,
+      ok: spec.ok(),
       tests: spec.tests.map(r => this._serializeTest(r)),
       file: toPosixPath(path.relative(this.config.testDir, spec.file)),
       line: spec.line,

--- a/test/json-reporter.spec.ts
+++ b/test/json-reporter.spec.ts
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { folio } from './fixtures';
+const { it, expect } = folio;
+
+it('should support spec.ok', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'a.test.js': `
+      it('math works!', async ({}) => {
+        expect(1 + 1).toBe(2);
+      });
+      it('math fails!', async ({}) => {
+        expect(1 + 1).toBe(3);
+      });
+    `
+  }, { });
+  expect(result.exitCode).toBe(1);
+  expect(result.report.suites[0].specs[0].ok).toBe(true);
+  expect(result.report.suites[0].specs[1].ok).toBe(false);
+});


### PR DESCRIPTION
It will drastically simplify understanding which specs
render total runs as "failing".