### PR TITLE
feat(parameters): setParameter override for a file

### DIFF
--- a/src/fixtures.ts
+++ b/src/fixtures.ts
@@ -84,11 +84,18 @@ export function assignParameters(params: any) {
   parameters = Object.assign(parameters, params);
 }
 
-export const matrix: { [name: string]: any } = {};
-export function setParameterValues(name: string, values: any[]) {
-  if (!(name in matrix))
+export const defaultParameterValues: { [name: string]: any } = {};
+export const cliParameterValues: { [name: string]: any } = {};
+export const localOverrideParameterRegistrations = new Map<string, any>();
+export function setParameterDefaultValues(name: string, values: any[]) {
+  if (!(name in defaultParameterValues))
     throw errorWithCallLocation(`Unregistered parameter '${name}' was set.`);
-  matrix[name] = values;
+  defaultParameterValues[name] = values;
+}
+export function setParameterCliValues(name: string, values: any[]) {
+  if (!(name in defaultParameterValues))
+    throw errorWithCallLocation(`Unregistered parameter '${name}' was set.`);
+  cliParameterValues[name] = values;
 }
 
 export let config: Config = {} as any;
@@ -244,7 +251,7 @@ export class FixturePool {
     if (parameterRegistrations.has(parameter.name))
       throw errorWithCallLocation(`Parameter "${parameter.name}" has been already registered`);
     parameterRegistrations.set(parameter.name, parameter);
-    matrix[parameter.name] = [parameter.defaultValue];
+    defaultParameterValues[parameter.name] = [parameter.defaultValue];
   }
 
   validate() {

--- a/src/runnerTest.ts
+++ b/src/runnerTest.ts
@@ -34,6 +34,7 @@ export class RunnerSuite extends Suite {
   _modifierFn: ModifierFn | null;
   _usedParameters: string[] = [];
   _hooks: { type: string, fn: Function, stack: string } [] = [];
+  _parameterOverrides = new Map<string, any>();
 
   _collectUsedParameters(result: Set<string>) {
     for (const param of this._usedParameters)

--- a/src/testGenerator.ts
+++ b/src/testGenerator.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { matrix } from './fixtures';
+import { defaultParameterValues, cliParameterValues } from './fixtures';
 import { Configuration } from './ipc';
 import { Config } from './config';
 import { RunnerSuite, RunnerSpec, RunnerTest, ModifierFn } from './runnerTest';
@@ -41,7 +41,7 @@ export function generateTests(suites: RunnerSuite[], config: Config): RunnerSuit
       // For generator fixtures, collect all variants of the fixture values
       // to build different workers for them.
       for (const name of spec._allUsedParameters()) {
-        const values = matrix[name];
+        const values = name in cliParameterValues ? cliParameterValues[name] : (suite._parameterOverrides.has(name) ? suite._parameterOverrides.get(name) : defaultParameterValues[name]);
         const state = generatorConfigurations.length ? generatorConfigurations.slice() : [[]];
         generatorConfigurations.length = 0;
         for (const gen of state) {

--- a/test/assets/local-parameter-override.ts
+++ b/test/assets/local-parameter-override.ts
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { folio as baseFolio } from '../../';
+
+const builder = baseFolio.extend<{ fixture1: string, fixture2: string }, {}, { param1: string, param2: string, param3: string }>();
+builder.param1.initParameter('Custom parameter 1', '');
+builder.param2.initParameter('Custom parameter 2', 'default value 2');
+builder.param3.initParameter('Custom parameter 3', 'default value 3');
+builder.fixture1.init(async ({testInfo}, runTest) => {
+  await runTest(testInfo.parameters.param1 as string);
+});
+builder.fixture2.init(async ({testInfo}, runTest) => {
+  await runTest(testInfo.parameters.param2 as string);
+});
+const { it, expect, setParameter } = builder.build();
+setParameter('param1', 'local override 1');
+setParameter('param2', 'local override 2');
+it('pass', async ({ param1, param2, param3, fixture1, fixture2 }) => {
+  // Available as fixtures.
+  expect(param1).toBe('local override 1');
+  expect(param2).toBe('override from outside 2');
+  expect(param3).toBe('default value 3');
+  // Available as parameters to fixtures.
+  expect(fixture1).toBe('local override 1');
+  expect(fixture2).toBe('override from outside 2');
+});

--- a/test/register-parameter.spec.ts
+++ b/test/register-parameter.spec.ts
@@ -30,3 +30,10 @@ it('should fail on unknown parameters', async ({ runTest }) => {
   }).catch(e => e);
   expect(result.output).toContain(`unknown parameter 'param3'`);
 });
+
+it('should locally override parameters', async ({ runTest }) => {
+  const result = await runTest('local-parameter-override.ts', {
+    'param': ['param2=override from outside 2']
+  });
+  expect(result.exitCode).toBe(0);
+});


### PR DESCRIPTION
This adds an api like

```js
const {it, setParameter, expect} = require('./my-fixtures');
setParameter('param1', 'value1');
it('has the new value', async({param1}) => {
   expect(param1).toBe('value1');
});
```

Right now it only works at the top level, but I think it should also work inside a describe:

```js
const {it, setParameter, expect} = require('./my-fixtures');
describe('my suite 1', () => {
  setParameter('param1', 'value1');
  it('has the new value', async({param1}) => {
    expect(param1).toBe('value1');
  });
});
describe('my suite 2', () => {
  setParameter('param1', 'value2');
  it('has the new value', async({param1}) => {
    expect(param1).toBe('value2');
  });
});
```

This splits the parameters matrix into three:
parameters from cli > parameters from setParameter > parameter defaultValues

Maybe in a future api, these should be to optionally consume the parameter. so `consumeParameter('browser', 'chromium')` will remove the `browser` parameter from the cli and lock its value to `chromium`.