### PR TITLE
feat: consider all flakes to be "expected"

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,46 +292,27 @@ Possible annotations include:
    ```ts
    test.fixme('Crashes the database server. Better not run it. We should fix that.');
    ```
-- `flaky` marks the test as either passing or failing. Folio will run this test, and consider it passing if at least one retry succeeds.
-   ```ts
-   test.flaky('Oh well...');
-   ```
 
 ### Flaky tests
 
-Folio deals with flaky tests with retries and `flaky` annotations. Pass the maximum number of retries when running the tests:
+Folio deals with flaky tests with retries. Pass the maximum number of retries when running the tests:
 ```sh
 npx folio test/ --retries 3
 ```
 
-Failing tests will be retried multiple times until they pass, or the maximium number of retries is reached. By default, if the test fails at least once, Folio will report it as "unexpected flaky". For example, if the test passes on the second retry, Folio will report something like this:
+Failing tests will be retried multiple times until they pass, or the maximium number of retries is reached. By default, if the test fails at least once, Folio will report it as "flaky". For example, if the test passes on the second retry, Folio will report something like this:
 
 ```sh
 Running 1 test using 1 worker
 ××±
-1 unexpected flaky
+1 flaky
   1) my.test.js:1:1
     <Error from the first run>
     Retry #1
     <Error from the first retry>
 ```
 
-However, known flaky tests can be marked as `flaky`, so that Folio reports them as "expected flaky" and succeeds the test run.
-
-```ts
-it('my test', test => {
-  test.flaky('Database sometimes fails with the large table.');
-}, async ({ table }) => {
-  // Test goes here.
-});
-```
-
-If the test passes on the second retry, Folio will report something like this:
-```sh
-Running 1 test using 1 worker
-××±
-  1 expected flaky
-```
+If the test is flaky, the test run will be considered succeeded.
 
 ## Built-in fixtures
 

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "eslint-plugin-notice": "^0.9.10",
     "folio": "./dogfood/node_modules/folio",
     "micromatch": "^4.0.2",
-    "typescript": "^4.0.2",
+    "typescript": "=4.0.2",
     "xml2js": "^0.4.23"
   },
   "license": "Apache-2.0",

--- a/src/reporters/base.ts
+++ b/src/reporters/base.ts
@@ -96,17 +96,15 @@ export class BaseReporter implements Reporter  {
   epilogue(full: boolean) {
     let skipped = 0;
     let expected = 0;
-    let expectedFlaky = 0;
     const unexpected: Test[] = [];
-    const unexpectedFlaky: Test[] = [];
+    const flaky: Test[] = [];
 
     this.suite.findTest(test => {
       switch (test.status()) {
         case 'skipped': ++skipped; break;
         case 'expected': ++expected; break;
         case 'unexpected': unexpected.push(test); break;
-        case 'expected-flaky': ++expectedFlaky; break;
-        case 'unexpected-flaky': unexpectedFlaky.push(test); break;
+        case 'flaky': flaky.push(test); break;
       }
     });
 
@@ -118,18 +116,16 @@ export class BaseReporter implements Reporter  {
       console.log(colors.red(`  ${unexpected.length} failed`));
       this._printTestHeaders(unexpected);
     }
-    if (expectedFlaky)
-      console.log(colors.yellow(`  ${expectedFlaky} expected flaky`));
-    if (unexpectedFlaky.length) {
-      console.log(colors.red(`  ${unexpectedFlaky.length} unexpected flaky`));
-      this._printTestHeaders(unexpectedFlaky);
+    if (flaky.length) {
+      console.log(colors.red(`  ${flaky.length} flaky`));
+      this._printTestHeaders(flaky);
     }
     if (this.timeout)
       console.log(colors.red(`  Timed out waiting ${this.timeout / 1000}s for the entire test run`));
 
-    if (full && unexpected.length + unexpectedFlaky.length) {
+    if (full && unexpected.length) {
       console.log('');
-      this._printFailures([...unexpected, ...unexpectedFlaky]);
+      this._printFailures(unexpected);
     }
     this._printSlowTests();
   }

--- a/src/reporters/dot.ts
+++ b/src/reporters/dot.ts
@@ -38,8 +38,7 @@ class DotReporter extends BaseReporter {
     switch (test.status()) {
       case 'expected': process.stdout.write(colors.green('·')); break;
       case 'unexpected': process.stdout.write(colors.red(test.results[test.results.length - 1].status === 'timedOut' ? 'T' : 'F')); break;
-      case 'expected-flaky': process.stdout.write(colors.yellow('±')); break;
-      case 'unexpected-flaky': process.stdout.write(colors.red('±')); break;
+      case 'flaky': process.stdout.write(colors.yellow('±')); break;
     }
   }
 

--- a/src/test.ts
+++ b/src/test.ts
@@ -167,7 +167,6 @@ export class Test {
   results: TestResult[] = [];
 
   skipped = false;
-  flaky = false;
   slow = false;
   expectedStatus: TestStatus = 'passed';
   timeout = 0;
@@ -177,7 +176,7 @@ export class Test {
     this.spec = spec;
   }
 
-  status(): 'skipped' | 'expected' | 'unexpected' | 'expected-flaky' | 'unexpected-flaky' {
+  status(): 'skipped' | 'expected' | 'unexpected' | 'flaky' {
     if (this.skipped)
       return 'skipped';
     // List mode bail out.
@@ -194,13 +193,13 @@ export class Test {
         hasPassedResults = true;
     }
     if (hasPassedResults)
-      return this.flaky ? 'expected-flaky' : 'unexpected-flaky';
+      return 'flaky';
     return 'unexpected';
   }
 
   ok(): boolean {
     const status = this.status();
-    return status === 'expected' || status === 'expected-flaky' || status === 'skipped';
+    return status === 'expected' || status === 'flaky' || status === 'skipped';
   }
 }
 

--- a/src/testGenerator.ts
+++ b/src/testGenerator.ts
@@ -74,7 +74,6 @@ export function generateTests(suites: RunnerSuite[], config: Config): RunnerSuit
           const test = new RunnerTest(spec);
           test.parameters = parameters;
           test.skipped = modifier._skipped;
-          test.flaky = modifier._flaky;
           test.slow = modifier._slow;
           test.expectedStatus = modifier._expectedStatus;
           test.timeout = modifier._timeout;

--- a/src/testModifier.ts
+++ b/src/testModifier.ts
@@ -18,7 +18,6 @@ import { TestStatus } from './ipc';
 
 export class TestModifier {
   _skipped = false;
-  _flaky = false;
   _slow = false;
   _expectedStatus?: TestStatus = 'passed';
   _annotations: any[] = [];
@@ -72,21 +71,6 @@ export class TestModifier {
       this._skipped = true;
       this._annotations.push({
         type: 'fixme',
-        description: processed.description
-      });
-    }
-  }
-
-  flaky(): void;
-  flaky(condition: boolean): void;
-  flaky(description: string): void;
-  flaky(condition: boolean, description: string): void;
-  flaky(arg?: boolean | string, description?: string) {
-    const processed = this._interpretCondition(arg, description);
-    if (processed.condition) {
-      this._flaky = true;
-      this._annotations.push({
-        type: 'flaky',
         description: processed.description
       });
     }

--- a/test/dot-reporter.spec.ts
+++ b/test/dot-reporter.spec.ts
@@ -56,27 +56,10 @@ it('render unexpected after retry', async ({ runInlineTest }) => {
   expect(result.exitCode).toBe(1);
 });
 
-it('render unexpected flaky', async ({ runInlineTest }) => {
+it('render flaky', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'a.test.js': `
-    it('one', async ({testInfo}) => {
-      expect(testInfo.retry).toBe(3);
-    });
-    `,
-  }, { retries: 3 });
-  const text = stripAscii(result.output);
-  expect(text).toContain('×××±');
-  expect(result.output).toContain(colors.red('±'));
-  expect(text).toContain('1 unexpected flaky');
-  expect(text).toContain('Retry #1');
-  expect(text).toContain('Retry #2');
-  expect(result.exitCode).toBe(1);
-});
-
-it('render expected flaky', async ({ runInlineTest }) => {
-  const result = await runInlineTest({
-    'a.test.js': `
-      it('one', test => test.flaky(), async ({testInfo}) => {
+      it('one', async ({testInfo}) => {
         expect(testInfo.retry).toBe(3);
       });
     `,
@@ -84,7 +67,7 @@ it('render expected flaky', async ({ runInlineTest }) => {
   const text = stripAscii(result.output);
   expect(text).toContain('×××±');
   expect(result.output).toContain(colors.yellow('±'));
-  expect(text).toContain('1 expected flaky');
+  expect(text).toContain('1 flaky');
   expect(text).not.toContain('Retry #1');
   expect(result.exitCode).toBe(0);
 });

--- a/test/exit-code.spec.ts
+++ b/test/exit-code.spec.ts
@@ -54,16 +54,13 @@ it('should repeat each', async ({ runTest }) => {
 it('should allow flaky', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'a.test.js': `
-      it('flake', test => {
-        test.flaky();
-      }, async ({ testInfo }) => {
+      it('flake', async ({ testInfo }) => {
         expect(testInfo.retry).toBe(1);
       });
     `,
   }, { retries: 1 });
   expect(result.exitCode).toBe(0);
-  expect(result.expectedFlaky).toBe(1);
-  expect(result.unexpectedFlaky).toBe(0);
+  expect(result.flaky).toBe(1);
 });
 
 it('should fail on unexpected pass', async ({ runTest }) => {

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -26,8 +26,7 @@ export type RunResult = {
   output: string,
   passed: number,
   failed: number,
-  expectedFlaky: number,
-  unexpectedFlaky: number,
+  flaky: number,
   skipped: number,
   report: ReportFormat,
   results: any[],
@@ -70,8 +69,7 @@ async function innerRunTest(baseDir: string, filePath: string, outputDir: string
   const status = await new Promise<number>(x => testProcess.on('close', x));
   const passed = (/(\d+) passed/.exec(output.toString()) || [])[1] || '0';
   const failed = (/(\d+) failed/.exec(output.toString()) || [])[1] || '0';
-  const expectedFlaky = (/(\d+) expected flaky/.exec(output.toString()) || [])[1] || '0';
-  const unexpectedFlaky = (/(\d+) unexpected flaky/.exec(output.toString()) || [])[1] || '0';
+  const flaky = (/(\d+) flaky/.exec(output.toString()) || [])[1] || '0';
   const skipped = (/(\d+) skipped/.exec(output.toString()) || [])[1] || '0';
   let report;
   try {
@@ -100,8 +98,7 @@ async function innerRunTest(baseDir: string, filePath: string, outputDir: string
     output,
     passed: parseInt(passed, 10),
     failed: parseInt(failed, 10),
-    expectedFlaky: parseInt(expectedFlaky, 10),
-    unexpectedFlaky: parseInt(unexpectedFlaky, 10),
+    flaky: parseInt(flaky, 10),
     skipped: parseInt(skipped, 10),
     report,
     results,

--- a/test/junit-reporter.spec.ts
+++ b/test/junit-reporter.spec.ts
@@ -79,23 +79,10 @@ it('render unexpected after retry', async ({ runInlineTest }) => {
   expect(result.exitCode).toBe(1);
 });
 
-it('render unexpected flaky', async ({ runInlineTest }) => {
+it('render flaky', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'a.test.js': `
-    it('one', async ({testInfo}) => {
-      expect(testInfo.retry).toBe(3);
-    });
-    `,
-  }, { retries: 3, reporter: 'junit' });
-  expect(result.output).toContain('Retry #1');
-  expect(result.output).toContain('Retry #2');
-  expect(result.exitCode).toBe(1);
-});
-
-it('render expected flaky', async ({ runInlineTest }) => {
-  const result = await runInlineTest({
-    'a.test.js': `
-      it('one', test => test.flaky(), async ({testInfo}) => {
+      it('one', async ({testInfo}) => {
         expect(testInfo.retry).toBe(3);
       });
     `,
@@ -107,7 +94,7 @@ it('render expected flaky', async ({ runInlineTest }) => {
 it('render stdout', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'a.test.js': `
-      it('one', test => test.flaky(), async ({testInfo}) => {
+      it('one', async ({testInfo}) => {
         console.log('Hello world');
       });
     `,

--- a/test/line-reporter.spec.ts
+++ b/test/line-reporter.spec.ts
@@ -35,32 +35,15 @@ it('render unexpected after retry', async ({ runInlineTest }) => {
   expect(result.exitCode).toBe(1);
 });
 
-it('render unexpected flaky', async ({ runInlineTest }) => {
+it('render flaky', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'a.test.js': `
-    it('one', async ({testInfo}) => {
-      expect(testInfo.retry).toBe(3);
-    });
-    `,
-  }, { retries: 3, reporter: 'line' });
-  const text = stripAscii(result.output);
-  expect(text).toContain('1 unexpected flaky');
-  expect(text).toContain('1) a.test');
-  expect(text).not.toContain('2) a.test');
-  expect(text).toContain('Retry #1');
-  expect(text).toContain('Retry #2');
-  expect(result.exitCode).toBe(1);
-});
-
-it('render expected flaky', async ({ runInlineTest }) => {
-  const result = await runInlineTest({
-    'a.test.js': `
-      it('one', test => test.flaky(), async ({testInfo}) => {
+      it('one', async ({testInfo}) => {
         expect(testInfo.retry).toBe(3);
       });
     `,
   }, { retries: 3, reporter: 'line' });
   const text = stripAscii(result.output);
-  expect(text).toContain('1 expected flaky');
+  expect(text).toContain('1 flaky');
   expect(result.exitCode).toBe(0);
 });

--- a/test/output-path.spec.ts
+++ b/test/output-path.spec.ts
@@ -35,12 +35,12 @@ it('should include repeat token', async ({runInlineTest}) => {
 it('should include retry token', async ({runInlineTest}) => {
   const result = await runInlineTest({
     'a.spec.js': `
-      it('test', test => test.flaky(), ({testInfo}) => {
+      it('test', ({testInfo}) => {
         expect(testInfo.outputPath('')).toContain('retry' + testInfo.retry);
         expect(testInfo.retry).toBe(2);
       });
     `
   }, { 'retries': 2 });
   expect(result.exitCode).toBe(0);
-  expect(result.expectedFlaky).toBe(1);
+  expect(result.flaky).toBe(1);
 });

--- a/test/retry.spec.ts
+++ b/test/retry.spec.ts
@@ -20,9 +20,8 @@ const { it, expect } = folio;
 
 it('should retry failures', async ({ runTest }) => {
   const result = await runTest('retry-failures.js', { retries: 10 });
-  expect(result.exitCode).toBe(1);
-  expect(result.expectedFlaky).toBe(0);
-  expect(result.unexpectedFlaky).toBe(1);
+  expect(result.exitCode).toBe(0);
+  expect(result.flaky).toBe(1);
   expect(result.results.length).toBe(2);
   expect(result.results[0].workerIndex).toBe(0);
   expect(result.results[0].retry).toBe(0);

--- a/test/test-output-dir-fixture.spec.ts
+++ b/test/test-output-dir-fixture.spec.ts
@@ -33,7 +33,7 @@ it('should work and remove empty dir', async ({ runInlineTest }) => {
       });
     `,
   }, { retries: 10 });
-  expect(result.exitCode).toBe(1);
+  expect(result.exitCode).toBe(0);
 
   expect(result.results[0].status).toBe('failed');
   expect(result.results[0].retry).toBe(0);


### PR DESCRIPTION
This patch:
- removes `test.flaky` modifier
- merges `expected-flaky` and `unexpected-flaky` test statuses together.
  Now all flakes are considered "expected".

Now if a test flakes:
- it doesn't kill build
- flaked test is printed out in the epilogue