### PR TITLE
fix: rename --list to --skip-all

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -146,7 +146,7 @@ async function runTests(command) {
     config.workers = parseInt(command.workers, 10);
 
   runner.generateTests({ parameters });
-  if (command.list) {
+  if (command.skipAll) {
     runner.list();
     return;
   }
@@ -205,7 +205,7 @@ function addRunnerOptions(program: commander.Command, param: boolean) {
       .option('--global-timeout <timeout>', `Specify maximum time this test suite can run in milliseconds (default: 0 for unlimited)`)
       .option('-h, --help', `Display help`)
       .option('-j, --workers <workers>', `Number of concurrent workers, use 1 to run in single worker (default: number of CPU cores / 2)`)
-      .option('--list', `Only collect all the test and report them`)
+      .option('--skip-all', `Only collect all the test and report them`)
       .option('--max-failures <N>', `Stop after the first N failures (default: ${defaultConfig.maxFailures})`)
       .option('--output <outputDir>', `Folder for output artifacts (default: "test-results")`);
   if (param)

--- a/test/list-mode.spec.ts
+++ b/test/list-mode.spec.ts
@@ -51,7 +51,7 @@ it('should work with parameters', async ({ runInlineFixturesTest }) => {
         expect(true).toBe(false);
       });
     `,
-  }, { 'list': true });
+  }, { 'skip-all': true });
   expect(result.exitCode).toBe(0);
   const suites = result.report.suites;
   expect(suites[0].file).toContain('a.test.js');
@@ -82,7 +82,7 @@ it('should emit test annotations', async ({ runInlineTest }) => {
         expect(true).toBe(false);
       });
     `
-  }, { 'list': true });
+  }, { 'skip-all': true });
   expect(result.exitCode).toBe(0);
   expect(result.report.suites[0].specs[0].tests[0].annotations).toEqual([{ type: 'fail', description: 'Fail annotation' }]);
 });
@@ -94,7 +94,7 @@ it('should have relative always-posix paths', async ({ runInlineTest }) => {
         expect(1 + 1).toBe(2);
       });
     `
-  }, { 'list': true });
+  }, { 'skip-all': true });
   expect(result.exitCode).toBe(0);
   expect(result.report.config.testDir.indexOf(path.win32.sep)).toBe(-1);
   expect(result.report.config.outputDir.indexOf(path.win32.sep)).toBe(-1);
@@ -114,7 +114,7 @@ it('should emit suite annotations', async ({ runInlineTest }) => {
         });
       });
     `
-  }, { 'list': true });
+  }, { 'skip-all': true });
   expect(result.exitCode).toBe(0);
   expect(result.report.suites[0].suites[0].specs[0].tests[0].annotations).toEqual([{ type: 'fixme', description: 'Fix me!' }]);
 });


### PR DESCRIPTION
Every time I see `--list` in the help, I think it will print the tests I'm about to run. But running it is pretty useless. I renamed it to say what it actually does. A follow up can add back `--list` that prints all the tests with the `list` reporter. That reporter is currently broken right now though.