### PR TITLE
fix(babel): ignore local babel config

### DIFF
--- a/src/transform.ts
+++ b/src/transform.ts
@@ -58,6 +58,8 @@ export function installTransform(): () => void {
       return fs.readFileSync(codePath, 'utf8');
 
     const result = babel.transformFileSync(filename, {
+      babelrc: false,
+      configFile: false,
       presets: [
         ['@babel/preset-env', { targets: {node: '10.17.0'} }],
         ['@babel/preset-typescript', { onlyRemoveTypeImports: true }],


### PR DESCRIPTION
Seems to be intended to be environment independent, so we should ignore these configs as e.g. react-scripts is also doing.

Fixes #160
Fixes https://github.com/microsoft/playwright-test/issues/207

cc @JoelEinbinder 
