### PR TITLE
feat: expose createTest with options

### DIFF
--- a/src/builtinFixtures.ts
+++ b/src/builtinFixtures.ts
@@ -14,20 +14,6 @@
  * limitations under the License.
  */
 
-import type { TestInfo } from './fixtures';
-
-type BuiltinWorkerFixtures = {
-  // Worker index that runs this test.
-  testWorkerIndex: number;
-};
-
-type BuiltinTestFixtures = {
-  // Information about the test being run.
-  testInfo: TestInfo;
-  // Parameter-based relative path to be overridden, empty by default.
-  testParametersPathSegment: string;
-};
-
 async function testWorkerIndex({}, runTest) {
   // Worker injects the value for this one.
   await runTest(undefined as any);

--- a/src/fixtures.ts
+++ b/src/fixtures.ts
@@ -40,6 +40,7 @@ export type TestInfo = {
   fn: Function;
 
   // Parameters
+  options: folio.SuiteOptions;
   parameters: Parameters;
   workerIndex: number;
   repeatEachIndex: number;

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -62,7 +62,6 @@ export class Runner {
 
   loadFiles(files: string[]) {
     debugLog(`loadFiles`, files);
-    // First traverse tests.
     for (const file of files) {
       const suite = new RunnerSuite('');
       suite.file = file;

--- a/src/test.ts
+++ b/src/test.ts
@@ -26,6 +26,7 @@ class Base {
 
   _only = false;
   _ordinal: number;
+  _options: folio.SuiteOptions = {};
 
   constructor(title: string, parent?: Suite) {
     this.title = title;
@@ -42,6 +43,12 @@ class Base {
 
   fullTitle(): string {
     return this.titlePath().join(' ');
+  }
+
+  _fullOptions(): folio.SuiteOptions {
+    if (!this.parent)
+      return this._options;
+    return { ...this.parent._fullOptions(), ...this._options };
   }
 }
 

--- a/src/workerRunner.ts
+++ b/src/workerRunner.ts
@@ -139,6 +139,7 @@ export class WorkerRunner extends EventEmitter {
       line: test.line,
       column: test.column,
       fn: test.fn,
+      options: test._fullOptions(),
       parameters,
       repeatEachIndex: this._repeatEachIndex,
       workerIndex: this._workerIndex,

--- a/test/access-data.spec.ts
+++ b/test/access-data.spec.ts
@@ -27,7 +27,7 @@ it('should access error in fixture', async ({ runInlineTest }) => {
       export const toBeRenamed = { testFixtures: { postProcess } };
     `,
     'test-error-visible-in-fixture.spec.ts': `
-      it('ensure fixture handles test error', async ({ postProcess }) => {
+      test('ensure fixture handles test error', async ({ postProcess }) => {
         expect(true).toBe(false);
       });
     `
@@ -49,7 +49,7 @@ it('should access data in fixture', async ({ runInlineTest }) => {
       export const toBeRenamed = { testFixtures: { testInfoForward } };
     `,
     'test-data-visible-in-fixture.spec.ts': `
-      it('ensure fixture handles test error', async ({ testInfoForward }) => {
+      test('ensure fixture handles test error', async ({ testInfoForward }) => {
         console.log('console.log');
         console.error('console.error');
         expect(config.testDir).toBeTruthy();
@@ -58,7 +58,7 @@ it('should access data in fixture', async ({ runInlineTest }) => {
     `
   });
   expect(exitCode).toBe(0);
-  const testResult = report.suites[0].specs[0].tests[0].runs[0];
+  const testResult = report.suites[0].suites[0].specs[0].tests[0].runs[0];
   expect(testResult.data).toEqual({ 'myname': 'myvalue' });
   expect(testResult.stdout).toEqual([{ text: 'console.log\n' }]);
   expect(testResult.stderr).toEqual([{ text: 'console.error\n' }]);

--- a/test/base-reporter.spec.ts
+++ b/test/base-reporter.spec.ts
@@ -21,7 +21,7 @@ it('handle long test names', async ({ runInlineTest }) => {
   const title = 'title'.repeat(30);
   const result = await runInlineTest({
     'a.test.js': `
-      it('${title}', async ({}) => {
+      test('${title}', async ({}) => {
         expect(1).toBe(0);
       });
     `,

--- a/test/basic.spec.ts
+++ b/test/basic.spec.ts
@@ -20,7 +20,7 @@ const { it, expect } = folio;
 it('should fail', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'one-failure.spec.ts': `
-      it('fails', () => {
+      test('fails', () => {
         expect(1 + 1).toBe(7);
       });
     `
@@ -34,7 +34,7 @@ it('should fail', async ({ runInlineTest }) => {
 it('should timeout', async ({ runInlineTest }) => {
   const { exitCode, passed, failed, output } = await runInlineTest({
     'one-timeout.spec.js': `
-      it('timeout', async () => {
+      test('timeout', async () => {
         await new Promise(f => setTimeout(f, 10000));
       });
     `
@@ -48,7 +48,7 @@ it('should timeout', async ({ runInlineTest }) => {
 it('should succeed', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'one-success.spec.js': `
-      it('succeeds', () => {
+      test('succeeds', () => {
         expect(1 + 1).toBe(2);
       });
     `
@@ -64,7 +64,7 @@ it('should report suite errors', async ({ runInlineTest }) => {
       if (new Error().stack.includes('workerRunner'))
         throw new Error('Suite error');
 
-      it('passes',() => {
+      test('passes',() => {
         expect(1 + 1).toBe(2);
       });
     `
@@ -77,10 +77,10 @@ it('should report suite errors', async ({ runInlineTest }) => {
 it('should respect nested skip', async ({ runInlineTest }) => {
   const { exitCode, passed, failed, skipped } = await runInlineTest({
     'nested-skip.spec.js': `
-      describe('skipped', suite => {
+      test.describe('skipped', suite => {
         suite.skip(true);
       }, () => {
-        it('succeeds',() => {
+        test('succeeds',() => {
           expect(1 + 1).toBe(2);
         });
       });
@@ -95,7 +95,7 @@ it('should respect nested skip', async ({ runInlineTest }) => {
 it('should respect slow test', async ({ runInlineTest }) => {
   const { exitCode, output } = await runInlineTest({
     'slow.spec.js': `
-      it('slow', test => {
+      test('slow', test => {
         test.slow();
       }, async () => {
         await new Promise(f => setTimeout(f, 10000));
@@ -109,26 +109,26 @@ it('should respect slow test', async ({ runInlineTest }) => {
 it('should respect excluded tests', async ({ runInlineTest }) => {
   const { exitCode, passed } = await runInlineTest({
     'excluded.spec.ts': `
-      it('included test', () => {
+      test('included test', () => {
         expect(1 + 1).toBe(2);
       });
 
-      xit('excluded test', () => {
+      test.skip('excluded test', () => {
         expect(1 + 1).toBe(3);
       });
 
-      it.skip('excluded test', () => {
+      test.skip('excluded test', () => {
         expect(1 + 1).toBe(3);
       });
 
-      describe('included describe', () => {
-        it('included describe test', () => {
+      test.describe('included describe', () => {
+        test('included describe test', () => {
           expect(1 + 1).toBe(2);
         });
       });
 
-      describe.skip('excluded describe', () => {
-        it('excluded describe test', () => {
+      test.describe.skip('excluded describe', () => {
+        test('excluded describe test', () => {
           expect(1 + 1).toBe(3);
         });
       });
@@ -141,41 +141,41 @@ it('should respect excluded tests', async ({ runInlineTest }) => {
 it('should respect focused tests', async ({ runInlineTest }) => {
   const { exitCode, passed } = await runInlineTest({
     'focused.spec.ts': `
-      it('included test', () => {
+      test('included test', () => {
         expect(1 + 1).toBe(3);
       });
 
-      fit('focused test', () => {
+      test.only('focused test', () => {
         expect(1 + 1).toBe(2);
       });
 
-      it.only('focused only test', () => {
+      test.only('focused only test', () => {
         expect(1 + 1).toBe(2);
       });
 
-      describe.only('focused describe', () => {
-        it('describe test', () => {
+      test.describe.only('focused describe', () => {
+        test('describe test', () => {
           expect(1 + 1).toBe(2);
         });
       });
 
-      describe('non-focused describe', () => {
-        it('describe test', () => {
+      test.describe('non-focused describe', () => {
+        test('describe test', () => {
           expect(1 + 1).toBe(3);
         });
       });
 
-      describe.only('focused describe', () => {
-        it('test1', () => {
+      test.describe.only('focused describe', () => {
+        test('test1', () => {
           expect(1 + 1).toBe(2);
         });
-        it.only('test2', () => {
+        test.only('test2', () => {
           expect(1 + 1).toBe(2);
         });
-        it('test3', () => {
+        test('test3', () => {
           expect(1 + 1).toBe(2);
         });
-        it.only('test4', () => {
+        test.only('test4', () => {
           expect(1 + 1).toBe(2);
         });
       });

--- a/test/dot-reporter.spec.ts
+++ b/test/dot-reporter.spec.ts
@@ -21,7 +21,7 @@ const { it, expect } = folio;
 it('render expected', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'a.test.js': `
-      it('one', async ({}) => {
+      test('one', async ({}) => {
         expect(1).toBe(1);
       });
     `,
@@ -33,7 +33,7 @@ it('render expected', async ({ runInlineTest }) => {
 it('render unexpected', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'a.test.js': `
-      it('one', async ({}) => {
+      test('one', async ({}) => {
         expect(1).toBe(0);
       });
     `,
@@ -45,7 +45,7 @@ it('render unexpected', async ({ runInlineTest }) => {
 it('render unexpected after retry', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'a.test.js': `
-      it('one', async ({}) => {
+      test('one', async ({}) => {
         expect(1).toBe(0);
       });
     `,
@@ -59,7 +59,7 @@ it('render unexpected after retry', async ({ runInlineTest }) => {
 it('render flaky', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'a.test.js': `
-      it('one', async ({testInfo}) => {
+      test('one', async ({testInfo}) => {
         expect(testInfo.retry).toBe(3);
       });
     `,

--- a/test/exit-code.spec.ts
+++ b/test/exit-code.spec.ts
@@ -26,7 +26,7 @@ function monotonicTime(): number {
 it('should collect stdio', async ({ runInlineTest }) => {
   const { exitCode, report } = await runInlineTest({
     'stdio.spec.js': `
-      it('stdio', () => {
+      test('stdio', () => {
         process.stdout.write('stdout text');
         process.stdout.write(Buffer.from('stdout buffer'));
         process.stderr.write('stderr text');
@@ -35,7 +35,7 @@ it('should collect stdio', async ({ runInlineTest }) => {
     `
   });
   expect(exitCode).toBe(0);
-  const testResult = report.suites[0].specs[0].tests[0].runs[0];
+  const testResult = report.suites[0].suites[0].specs[0].tests[0].runs[0];
   const { stdout, stderr } = testResult;
   expect(stdout).toEqual([{ text: 'stdout text' }, { buffer: Buffer.from('stdout buffer').toString('base64') }]);
   expect(stderr).toEqual([{ text: 'stderr text' }, { buffer: Buffer.from('stderr buffer').toString('base64') }]);
@@ -62,11 +62,11 @@ it('should work with typescript', async ({ runInlineTest }) => {
     'typescript.spec.ts': `
       import './global-foo';
 
-      it('should find global foo', () => {
+      test('should find global foo', () => {
         expect(global['foo']).toBe(true);
       });
 
-      it('should work with type annotations', () => {
+      test('should work with type annotations', () => {
         const x: number = 5;
         expect(x).toBe(5);
       });
@@ -78,21 +78,21 @@ it('should work with typescript', async ({ runInlineTest }) => {
 it('should repeat each', async ({ runInlineTest }) => {
   const { exitCode, report } = await runInlineTest({
     'one-success.spec.js': `
-      it('succeeds', () => {
+      test('succeeds', () => {
         expect(1 + 1).toBe(2);
       });
     `
   }, { 'repeat-each': 3 });
   expect(exitCode).toBe(0);
   expect(report.suites.length).toBe(1);
-  expect(report.suites[0].specs.length).toBe(1);
-  expect(report.suites[0].specs[0].tests.length).toBe(3);
+  expect(report.suites[0].suites[0].specs.length).toBe(1);
+  expect(report.suites[0].suites[0].specs[0].tests.length).toBe(3);
 });
 
 it('should allow flaky', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'a.test.js': `
-      it('flake', async ({ testInfo }) => {
+      test('flake', async ({ testInfo }) => {
         expect(testInfo.retry).toBe(1);
       });
     `,
@@ -104,7 +104,7 @@ it('should allow flaky', async ({ runInlineTest }) => {
 it('should fail on unexpected pass', async ({ runInlineTest }) => {
   const { exitCode, failed, output } = await runInlineTest({
     'unexpected-pass.spec.js': `
-      it('succeeds', test => test.fail(), () => {
+      test('succeeds', test => test.fail(), () => {
         expect(1 + 1).toBe(2);
       });
     `
@@ -118,7 +118,7 @@ it('should respect global timeout', async ({ runInlineTest }) => {
   const now = monotonicTime();
   const { exitCode, output } = await runInlineTest({
     'one-timeout.spec.js': `
-      it('timeout', async () => {
+      test('timeout', async () => {
         await new Promise(f => setTimeout(f, 10000));
       });
     `

--- a/test/fixture-errors.spec.ts
+++ b/test/fixture-errors.spec.ts
@@ -27,11 +27,11 @@ it('should handle fixture timeout', async ({ runInlineTest }) => {
       export const toBeRenamed = { testFixtures: { timeout } };
     `,
     'a.spec.ts': `
-      it('fixture timeout', async ({timeout}) => {
+      test('fixture timeout', async ({timeout}) => {
         expect(1).toBe(1);
       });
 
-      it('failing fixture timeout', async ({timeout}) => {
+      test('failing fixture timeout', async ({timeout}) => {
         expect(1).toBe(2);
       });
     `
@@ -49,7 +49,7 @@ it('should handle worker fixture timeout', async ({ runInlineTest }) => {
       export const toBeRenamed = { workerFixtures: { timeout } };
     `,
     'a.spec.ts': `
-      it('fails', async ({timeout}) => {
+      test('fails', async ({timeout}) => {
       });
     `
   }, { timeout: 500 });
@@ -66,7 +66,7 @@ it('should handle test fixture error', async ({ runInlineTest }) => {
       export const toBeRenamed = { testFixtures: { failure } };
     `,
     'a.spec.ts': `
-      it('fails', async ({failure}) => {
+      test('fails', async ({failure}) => {
       });
     `
   });
@@ -85,7 +85,7 @@ it('should handle worker tear down fixture error', async ({ runInlineTest }) => 
       export const toBeRenamed = { workerFixtures: { failure } };
     `,
     'a.spec.ts': `
-      it('pass', async ({failure}) => {
+      test('pass', async ({failure}) => {
         expect(true).toBe(true);
       });
     `
@@ -109,7 +109,7 @@ it('should throw when defining worker fixture twice', async ({ runInlineTest }) 
       export const toBeRenamed = { workerFixtures: { foo } };
     `,
     'b.spec.ts': `
-      it('works', async ({foo}) => {});
+      test('works', async ({foo}) => {});
     `
   });
   expect(stripAscii(result.output)).toContain(`Fixture "foo" has already been registered. Use a different name for this fixture.`);
@@ -131,7 +131,7 @@ it('should throw when defining test fixture twice', async ({ runInlineTest }) =>
       export const toBeRenamed = { testFixtures: { foo } };
     `,
     'd.spec.ts': `
-      it('works', async ({foo}) => {});
+      test('works', async ({foo}) => {});
     `
   });
   expect(stripAscii(result.output)).toContain(`Fixture "foo" has already been registered. Use a different name for this fixture.`);
@@ -147,7 +147,7 @@ it('should throw when defining test fixture with the same name as a worker fixtu
       export const toBeRenamed = { testFixtures: { foo }, workerFixtures: { foo } };
     `,
     'e.spec.ts': `
-      it('works', async ({foo}) => {});
+      test('works', async ({foo}) => {});
     `,
   });
   expect(stripAscii(result.output)).toContain(`Fixture "foo" has already been registered as a { scope: 'worker' } fixture. Use a different name for this test fixture.`);
@@ -166,7 +166,7 @@ it('should throw when worker fixture depends on a test fixture', async ({ runInl
       export const toBeRenamed = { testFixtures: { foo }, workerFixtures: { bar } };
     `,
     'f.spec.ts': `
-      it('works', async ({bar}) => {});
+      test('works', async ({bar}) => {});
     `,
   });
   expect(stripAscii(result.output)).toContain('Worker fixture "bar" cannot depend on a test fixture "foo".');
@@ -188,7 +188,7 @@ it('should detect fixture dependency cycle', async ({ runInlineTest }) => {
       export const toBeRenamed = { testFixtures: { foo, bar, good1, baz, qux } };
     `,
     'dir/x.spec.ts': `
-      it('works', async ({foo}) => {});
+      test('works', async ({foo}) => {});
     `,
   });
   expect(stripAscii(result.output)).toContain('Fixtures "foo" -> "bar" -> "baz" -> "qux" -> "foo" form a dependency cycle.');
@@ -207,7 +207,7 @@ it('should detect fixture dependency cycle across files', async ({ runInlineTest
       export const toBeRenamed = { testFixtures: { qux } };
     `,
     'x.spec.ts': `
-      it('works', async ({foo}) => {});
+      test('works', async ({foo}) => {});
     `,
   });
   expect(stripAscii(result.output)).toContain('Fixtures "foo" -> "bar" -> "qux" -> "foo" form a dependency cycle.');
@@ -224,20 +224,20 @@ it('should throw when calling runTest twice', async ({ runInlineTest }) => {
       export const toBeRenamed = { testFixtures: { foo } };
     `,
     'f.spec.ts': `
-      it('works', async ({foo}) => {});
+      test('works', async ({foo}) => {});
     `,
   });
   expect(result.results[0].error.message).toBe('Cannot provide fixture value for the second time');
   expect(result.exitCode).toBe(1);
 });
 
-it('should throw when test is called in fixutres file', async ({ runInlineTest }) => {
+it('should throw when createTest is called in fixutres file', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'fixtures.js': `
-      it(async ({}) => {});
+      createTest({});
     `,
     'a.test.js': `
-      it('test', async ({}) => {
+      test('test', async ({}) => {
       });
     `,
   });

--- a/test/fixtures.spec.ts
+++ b/test/fixtures.spec.ts
@@ -25,7 +25,7 @@ it('should work', async ({ runInlineTest }) => {
       export const toBeRenamed = { testFixtures: { asdf } };
     `,
     'a.test.js': `
-      it('should use asdf', async ({asdf}) => {
+      test('should use asdf', async ({asdf}) => {
         expect(asdf).toBe(123);
       });
     `,
@@ -42,7 +42,7 @@ it('should work with a sync function', async ({ runInlineTest }) => {
       export const toBeRenamed = { testFixtures: { asdf } };
     `,
     'a.test.js': `
-      it('should use asdf', ({asdf}) => {
+      test('should use asdf', ({asdf}) => {
         expect(asdf).toBe(123);
       });
     `,
@@ -59,7 +59,7 @@ it('should work with a non-arrow function', async ({ runInlineTest }) => {
       export const toBeRenamed = { testFixtures: { asdf } };
     `,
     'a.test.js': `
-      it('should use asdf', function ({asdf}) {
+      test('should use asdf', function ({asdf}) {
         expect(asdf).toBe(123);
       });
     `,
@@ -76,7 +76,7 @@ it('should work with a named function', async ({ runInlineTest }) => {
       export const toBeRenamed = { testFixtures: { asdf } };
     `,
     'a.test.js': `
-      it('should use asdf', async function hello({asdf}) {
+      test('should use asdf', async function hello({asdf}) {
         expect(asdf).toBe(123);
       });
     `,
@@ -93,7 +93,7 @@ it('should work with renamed parameters', async ({ runInlineTest }) => {
       export const toBeRenamed = { testFixtures: { asdf } };
     `,
     'a.test.js': `
-      it('should use asdf', function ({asdf: renamed}) {
+      test('should use asdf', function ({asdf: renamed}) {
         expect(renamed).toBe(123);
       });
     `,
@@ -104,10 +104,10 @@ it('should work with renamed parameters', async ({ runInlineTest }) => {
 it('should fail if parameters are not destructured', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'a.test.js': `
-      it('should pass', function () {
+      test('should pass', function () {
         expect(1).toBe(1);
       });
-      it('should use asdf', function (abc) {
+      test('should use asdf', function (abc) {
         expect(abc.asdf).toBe(123);
       });
     `,
@@ -120,7 +120,7 @@ it('should fail if parameters are not destructured', async ({ runInlineTest }) =
 it('should fail with an unknown fixture', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'a.test.js': `
-      it('should use asdf', async ({asdf}) => {
+      test('should use asdf', async ({asdf}) => {
         expect(asdf).toBe(123);
       });
     `,
@@ -140,13 +140,13 @@ it('should run the fixture every time', async ({ runInlineTest }) => {
       export const toBeRenamed = { testFixtures: { asdf } };
     `,
     'a.test.js': `
-      it('should use asdf', async ({asdf}) => {
+      test('should use asdf', async ({asdf}) => {
         expect(asdf).toBe(0);
       });
-      it('should use asdf', async ({asdf}) => {
+      test('should use asdf', async ({asdf}) => {
         expect(asdf).toBe(1);
       });
-      it('should use asdf', async ({asdf}) => {
+      test('should use asdf', async ({asdf}) => {
         expect(asdf).toBe(2);
       });
     `,
@@ -164,13 +164,13 @@ it('should only run worker fixtures once', async ({ runInlineTest }) => {
       export const toBeRenamed = { workerFixtures: { asdf } };
     `,
     'a.test.js': `
-      it('should use asdf', async ({asdf}) => {
+      test('should use asdf', async ({asdf}) => {
         expect(asdf).toBe(0);
       });
-      it('should use asdf', async ({asdf}) => {
+      test('should use asdf', async ({asdf}) => {
         expect(asdf).toBe(0);
       });
-      it('should use asdf', async ({asdf}) => {
+      test('should use asdf', async ({asdf}) => {
         expect(asdf).toBe(0);
       });
     `,
@@ -190,19 +190,19 @@ it('all files should share fixtures', async ({ runInlineTest }) => {
       export const toBeRenamed = { testFixtures: { testFixture }, workerFixtures: { worker } };
     `,
     'a.test.js': `
-      it('should use worker', async ({worker, testFixture}) => {
+      test('should use worker', async ({worker, testFixture}) => {
         expect(worker).toBe('worker');
         expect(testFixture).toBe('test');
       });
     `,
     'b.test.js': `
-      it('should use worker', async ({worker, testFixture}) => {
+      test('should use worker', async ({worker, testFixture}) => {
         expect(worker).toBe('worker');
         expect(testFixture).toBe('test');
       });
     `,
     'c.test.js': `
-      it('should use worker', async ({worker, testFixture}) => {
+      test('should use worker', async ({worker, testFixture}) => {
         expect(worker).toBe('worker');
         expect(testFixture).toBe('test');
       });
@@ -222,10 +222,10 @@ it('tests respect automatic test fixtures', async ({ runInlineTest }) => {
       export const toBeRenamed = { autoTestFixtures: { automaticTestFixture } };
     `,
     'a.test.js': `
-      it('test 1', async ({}) => {
+      test('test 1', async ({}) => {
         expect(global.counter).toBe(1);
       });
-      it('test 2', async ({}) => {
+      test('test 2', async ({}) => {
         expect(global.counter).toBe(2);
       });
     `
@@ -245,10 +245,10 @@ it('tests respect automatic worker fixtures', async ({ runInlineTest }) => {
       export const toBeRenamed = { autoWorkerFixtures: { automaticWorkerFixture } };
     `,
     'a.test.js': `
-      it('test 1', async ({}) => {
+      test('test 1', async ({}) => {
         expect(global.counter).toBe(1);
       });
-      it('test 2', async ({}) => {
+      test('test 2', async ({}) => {
         expect(global.counter).toBe(1);
       });
     `
@@ -268,7 +268,7 @@ it('tests does not run non-automatic worker fixtures', async ({ runInlineTest })
       export const toBeRenamed = { workerFixtures: { workerFixture } };
     `,
     'a.test.js': `
-      it('test 1', async ({}) => {
+      test('test 1', async ({}) => {
         expect(global.counter).toBe(0);
       });
     `
@@ -297,7 +297,7 @@ it('should teardown fixtures after timeout', async ({ runInlineTest, testInfo })
       };
     `,
     'a.spec.ts': `
-      it('test', async ({t, w}) => {
+      test('test', async ({t, w}) => {
         expect(t).toBe('t');
         expect(w).toBe('w');
         await new Promise(() => {});

--- a/test/gitignore.spec.ts
+++ b/test/gitignore.spec.ts
@@ -21,10 +21,10 @@ it('should respect .gitignore', async ({runInlineTest}) => {
   const result = await runInlineTest({
     '.gitignore': `a.spec.js`,
     'a.spec.js': `
-      it('pass', ({}) => {});
+      test('pass', ({}) => {});
     `,
     'b.spec.js': `
-      it('pass', ({}) => {});
+      test('pass', ({}) => {});
     `
   });
   expect(result.exitCode).toBe(0);
@@ -35,10 +35,10 @@ it('should respect nested .gitignore', async ({runInlineTest}) => {
   const result = await runInlineTest({
     'a/.gitignore': `a.spec.js`,
     'a/a.spec.js': `
-      it('pass', ({}) => {});
+      test('pass', ({}) => {});
     `,
     'a/b.spec.js': `
-      it('pass', ({}) => {});
+      test('pass', ({}) => {});
     `
   });
   expect(result.exitCode).toBe(0);
@@ -49,10 +49,10 @@ it('should respect enclosing .gitignore', async ({runInlineTest}) => {
   const result = await runInlineTest({
     '.gitignore': `a/a.spec.js`,
     'a/a.spec.js': `
-      it('pass', ({}) => {});
+      test('pass', ({}) => {});
     `,
     'a/b.spec.js': `
-      it('pass', ({}) => {});
+      test('pass', ({}) => {});
     `
   });
   expect(result.exitCode).toBe(0);
@@ -63,10 +63,10 @@ it('should respect enclosing .gitignore', async ({runInlineTest}) => {
   const result = await runInlineTest({
     '.gitignore': `a/a.spec.js`,
     'a/a.spec.js': `
-      it('pass', ({}) => {});
+      test('pass', ({}) => {});
     `,
     'a/b.spec.js': `
-      it('pass', ({}) => {});
+      test('pass', ({}) => {});
     `
   });
   expect(result.exitCode).toBe(0);

--- a/test/golden.spec.ts
+++ b/test/golden.spec.ts
@@ -24,7 +24,7 @@ it('should support golden', async ({runInlineTest}) => {
   const result = await runInlineTest({
     '__snapshots__/a/is-a-test/snapshot.txt': `Hello world`,
     'a.spec.js': `
-      it('is a test', ({}) => {
+      test('is a test', ({}) => {
         expect('Hello world').toMatchSnapshot();
       });
     `
@@ -42,7 +42,7 @@ Line5
 Line6
 Line7`,
     'a.spec.js': `
-      it('is a test', ({}) => {
+      test('is a test', ({}) => {
         const data = [];
         data.push('Line1');
         data.push('Line22');
@@ -67,7 +67,7 @@ Line7`,
 it('should write missing expectations', async ({runInlineTest, testInfo}) => {
   const result = await runInlineTest({
     'a.spec.js': `
-      it('is a test', ({}) => {
+      test('is a test', ({}) => {
         expect('Hello world').toMatchSnapshot();
       });
     `
@@ -82,7 +82,7 @@ it('should update expectations', async ({runInlineTest, testInfo}) => {
   const result = await runInlineTest({
     '__snapshots__/a/is-a-test/snapshot.txt': `Hello world`,
     'a.spec.js': `
-      it('is a test', ({}) => {
+      test('is a test', ({}) => {
         expect('Hello world updated').toMatchSnapshot();
       });
     `
@@ -100,7 +100,7 @@ it('should match multiple snapshots', async ({runInlineTest}) => {
     '__snapshots__/a/is-a-test/snapshot_1.txt': `Snapshot2`,
     '__snapshots__/a/is-a-test/snapshot_2.txt': `Snapshot3`,
     'a.spec.js': `
-      it('is a test', ({}) => {
+      test('is a test', ({}) => {
         expect('Snapshot1').toMatchSnapshot();
         expect('Snapshot2').toMatchSnapshot();
         expect('Snapshot3').toMatchSnapshot();
@@ -114,7 +114,7 @@ it('should use provided name', async ({runInlineTest}) => {
   const result = await runInlineTest({
     '__snapshots__/a/is-a-test/provided.txt': `Hello world`,
     'a.spec.js': `
-      it('is a test', ({}) => {
+      test('is a test', ({}) => {
         expect('Hello world').toMatchSnapshot('provided.txt');
       });
     `
@@ -126,7 +126,7 @@ it('should use provided name via options', async ({runInlineTest}) => {
   const result = await runInlineTest({
     '__snapshots__/a/is-a-test/provided.txt': `Hello world`,
     'a.spec.js': `
-      it('is a test', ({}) => {
+      test('is a test', ({}) => {
         expect('Hello world').toMatchSnapshot({ name: 'provided.txt' });
       });
     `
@@ -138,7 +138,7 @@ it('should compare binary', async ({runInlineTest}) => {
   const result = await runInlineTest({
     '__snapshots__/a/is-a-test/snapshot.dat': Buffer.from([1,2,3,4]),
     'a.spec.js': `
-      it('is a test', ({}) => {
+      test('is a test', ({}) => {
         expect(Buffer.from([1,2,3,4])).toMatchSnapshot();
       });
     `
@@ -151,7 +151,7 @@ it('should compare PNG images', async ({runInlineTest}) => {
     '__snapshots__/a/is-a-test/snapshot.png':
         Buffer.from('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+P+/HgAFhAJ/wlseKgAAAABJRU5ErkJggg==', 'base64'),
     'a.spec.js': `
-      it('is a test', ({}) => {
+      test('is a test', ({}) => {
         expect(Buffer.from('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+P+/HgAFhAJ/wlseKgAAAABJRU5ErkJggg==', 'base64')).toMatchSnapshot();
       });
     `
@@ -164,7 +164,7 @@ it('should compare different PNG images', async ({runInlineTest}) => {
     '__snapshots__/a/is-a-test/snapshot.png':
         Buffer.from('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+P+/HgAFhAJ/wlseKgAAAABJRU5ErkJggg==', 'base64'),
     'a.spec.js': `
-      it('is a test', ({}) => {
+      test('is a test', ({}) => {
         expect(Buffer.from('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVQYV2NgYAAAAAMAAWgmWQ0AAAAASUVORK5CYII==', 'base64')).toMatchSnapshot();
       });
     `
@@ -181,7 +181,7 @@ it('should respect threshold', async ({runInlineTest}) => {
     '__snapshots__/a/is-a-test/snapshot.png': expected,
     '__snapshots__/a/is-a-test/snapshot2.png': expected,
     'a.spec.js': `
-      it('is a test', ({}) => {
+      test('is a test', ({}) => {
         expect(Buffer.from('${actual.toString('base64')}', 'base64')).toMatchSnapshot({ threshold: 0.3 });
         expect(Buffer.from('${actual.toString('base64')}', 'base64')).not.toMatchSnapshot({ threshold: 0.2 });
         expect(Buffer.from('${actual.toString('base64')}', 'base64')).toMatchSnapshot('snapshot2.png', { threshold: 0.3 });

--- a/test/hooks.spec.ts
+++ b/test/hooks.spec.ts
@@ -33,29 +33,29 @@ it('hooks should work with fixtures', async ({ runInlineTest }) => {
       export const toBeRenamed = { workerFixtures: { w }, testFixtures: { t } };
     `,
     'a.test.js': `
-      describe('suite', () => {
-        beforeAll(async ({w}) => {
+      test.describe('suite', () => {
+        test.beforeAll(async ({w}) => {
           global.logs.push('beforeAll-' + w);
         });
-        afterAll(async ({w}) => {
+        test.afterAll(async ({w}) => {
           global.logs.push('afterAll-' + w);
         });
 
-        beforeEach(async ({w, t}) => {
+        test.beforeEach(async ({w, t}) => {
           global.logs.push('beforeEach-' + w + '-' + t);
         });
-        afterEach(async ({w, t}) => {
+        test.afterEach(async ({w, t}) => {
           global.logs.push('afterEach-' + w + '-' + t);
         });
 
-        it('one', async ({w, t}) => {
+        test('one', async ({w, t}) => {
           global.logs.push('test');
           expect(w).toBe(17);
           expect(t).toBe(42);
         });
       });
 
-      it('two', async ({w}) => {
+      test('two', async ({w}) => {
         expect(global.logs).toEqual([
           '+w',
           'beforeAll-17',
@@ -83,15 +83,15 @@ it('afterEach failure should not prevent other hooks and fixture teardown', asyn
       export const toBeRenamed = { testFixtures: { t } };
     `,
     'a.test.js': `
-      describe('suite', () => {
-        afterEach(async ({}) => {
+      test.describe('suite', () => {
+        test.afterEach(async ({}) => {
           console.log('afterEach1');
         });
-        afterEach(async ({}) => {
+        test.afterEach(async ({}) => {
           console.log('afterEach2');
           throw new Error('afterEach2');
         });
-        it('one', async ({t}) => {
+        test('one', async ({t}) => {
           console.log('test');
           expect(t).toBe(42);
         });
@@ -105,18 +105,18 @@ it('afterEach failure should not prevent other hooks and fixture teardown', asyn
 it('beforeEach failure should prevent the test, but not other hooks', async ({ runInlineTest }) => {
   const report = await runInlineTest({
     'a.test.js': `
-      describe('suite', () => {
-        beforeEach(async ({}) => {
+      test.describe('suite', () => {
+        test.beforeEach(async ({}) => {
           console.log('beforeEach1');
         });
-        beforeEach(async ({}) => {
+        test.beforeEach(async ({}) => {
           console.log('beforeEach2');
           throw new Error('beforeEach2');
         });
-        afterEach(async ({}) => {
+        test.afterEach(async ({}) => {
           console.log('afterEach');
         });
-        it('one', async ({}) => {
+        test('one', async ({}) => {
           console.log('test');
         });
       });
@@ -126,25 +126,12 @@ it('beforeEach failure should prevent the test, but not other hooks', async ({ r
   expect(report.results[0].error.message).toContain('beforeEach2');
 });
 
-it('should throw when hook is called in fixutres file', async ({ runInlineTest }) => {
-  const result = await runInlineTest({
-    'fixtures.js': `
-      beforeEach(async ({}) => {});
-    `,
-    'a.test.js': `
-      it('test', async ({}) => {
-      });
-    `,
-  });
-  expect(stripAscii(result.output)).toContain('Hook cannot be defined in a fixture file.');
-});
-
 it('should throw when hook depends on unknown fixture', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'a.spec.ts': `
-      describe('suite', () => {
-        beforeEach(async ({foo}) => {});
-        it('works', async ({}) => {});
+      test.describe('suite', () => {
+        test.beforeEach(async ({foo}) => {});
+        test('works', async ({}) => {});
       });
     `,
   });
@@ -162,9 +149,9 @@ it('should throw when beforeAll hook depends on test fixture', async ({ runInlin
       export const toBeRenamed = { testFixtures: { foo } };
     `,
     'a.spec.ts': `
-      describe('suite', () => {
-        beforeAll(async ({foo}) => {});
-        it('works', async ({foo}) => {});
+      test.describe('suite', () => {
+        test.beforeAll(async ({foo}) => {});
+        test('works', async ({foo}) => {});
       });
     `,
   });
@@ -182,9 +169,9 @@ it('should throw when afterAll hook depends on test fixture', async ({ runInline
       export const toBeRenamed = { testFixtures: { foo } };
     `,
     'a.spec.ts': `
-      describe('suite', () => {
-        afterAll(async ({foo}) => {});
-        it('works', async ({foo}) => {});
+      test.describe('suite', () => {
+        test.afterAll(async ({foo}) => {});
+        test('works', async ({foo}) => {});
       });
     `,
   });

--- a/test/json-reporter.spec.ts
+++ b/test/json-reporter.spec.ts
@@ -20,15 +20,15 @@ const { it, expect } = folio;
 it('should support spec.ok', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'a.test.js': `
-      it('math works!', async ({}) => {
+      test('math works!', async ({}) => {
         expect(1 + 1).toBe(2);
       });
-      it('math fails!', async ({}) => {
+      test('math fails!', async ({}) => {
         expect(1 + 1).toBe(3);
       });
     `
   }, { });
   expect(result.exitCode).toBe(1);
-  expect(result.report.suites[0].specs[0].ok).toBe(true);
-  expect(result.report.suites[0].specs[1].ok).toBe(false);
+  expect(result.report.suites[0].suites[0].specs[0].ok).toBe(true);
+  expect(result.report.suites[0].suites[0].specs[1].ok).toBe(false);
 });

--- a/test/junit-reporter.spec.ts
+++ b/test/junit-reporter.spec.ts
@@ -21,12 +21,12 @@ const { it, expect } = folio;
 it('render expected', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'a.test.js': `
-      it('one', async ({}) => {
+      test('one', async ({}) => {
         expect(1).toBe(1);
       });
     `,
     'b.test.js': `
-      it('two', async ({}) => {
+      test('two', async ({}) => {
         expect(1).toBe(1);
       });
     `,
@@ -46,7 +46,7 @@ it('render expected', async ({ runInlineTest }) => {
 it('render unexpected', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'a.test.js': `
-      it('one', async ({}) => {
+      test('one', async ({}) => {
         expect(1).toBe(0);
       });
     `,
@@ -65,7 +65,7 @@ it('render unexpected', async ({ runInlineTest }) => {
 it('render unexpected after retry', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'a.test.js': `
-      it('one', async ({}) => {
+      test('one', async ({}) => {
         expect(1).toBe(0);
       });
     `,
@@ -82,7 +82,7 @@ it('render unexpected after retry', async ({ runInlineTest }) => {
 it('render flaky', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'a.test.js': `
-      it('one', async ({testInfo}) => {
+      test('one', async ({testInfo}) => {
         expect(testInfo.retry).toBe(3);
       });
     `,
@@ -94,7 +94,7 @@ it('render flaky', async ({ runInlineTest }) => {
 it('render stdout', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'a.test.js': `
-      it('one', async ({testInfo}) => {
+      test('one', async ({testInfo}) => {
         console.log('Hello world');
       });
     `,
@@ -109,10 +109,10 @@ it('render stdout', async ({ runInlineTest }) => {
 it('render skipped', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'a.test.js': `
-      it('one', async () => {
+      test('one', async () => {
         console.log('Hello world');
       });
-      it('two', test => test.skip(), async () => {
+      test('two', test => test.skip(), async () => {
         console.log('Hello world');
       });
     `,

--- a/test/line-reporter.spec.ts
+++ b/test/line-reporter.spec.ts
@@ -20,7 +20,7 @@ const { it, expect } = folio;
 it('render unexpected after retry', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'a.test.js': `
-      it('one', async ({}) => {
+      test('one', async ({}) => {
         expect(1).toBe(0);
       });
     `,
@@ -38,7 +38,7 @@ it('render unexpected after retry', async ({ runInlineTest }) => {
 it('render flaky', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'a.test.js': `
-      it('one', async ({testInfo}) => {
+      test('one', async ({testInfo}) => {
         expect(testInfo.retry).toBe(3);
       });
     `,

--- a/test/list-mode.spec.ts
+++ b/test/list-mode.spec.ts
@@ -24,21 +24,21 @@ it('should work with parameters', async ({ runInlineTest }) => {
       exports.toBeRenamed = { parameters: { worker: { description: '', defaultValue: '', values: ['A', 'B', 'C'] } } };
     `,
     'a.test.js': `
-      it('should use worker A', (test, parameters) => {
+      test('should use worker A', (test, parameters) => {
         test.fail(parameters.worker !== 'A');
       }, async ({worker}) => {
         expect(true).toBe(false);
       });
     `,
     'b.test.js': `
-      it('should use worker B', (test, parameters) => {
+      test('should use worker B', (test, parameters) => {
         test.fail(parameters.worker !== 'B');
       }, async ({worker}) => {
         expect(true).toBe(false);
       });
     `,
     'c.test.js': `
-      it('should use worker C', (test, parameters) => {
+      test('should use worker C', (test, parameters) => {
         test.fail(parameters.worker !== 'C');
       }, async ({worker}) => {
         expect(true).toBe(false);
@@ -48,15 +48,15 @@ it('should work with parameters', async ({ runInlineTest }) => {
   expect(result.exitCode).toBe(0);
   const suites = result.report.suites;
   expect(suites[0].file).toContain('a.test.js');
-  expect(suites[0].specs[0].tests.length).toBe(3);
+  expect(suites[0].suites[0].specs[0].tests.length).toBe(3);
   expect(suites[1].file).toContain('b.test.js');
-  expect(suites[1].specs[0].tests.length).toBe(3);
+  expect(suites[1].suites[0].specs[0].tests.length).toBe(3);
   expect(suites[2].file).toContain('c.test.js');
-  expect(suites[2].specs[0].tests.length).toBe(3);
+  expect(suites[2].suites[0].specs[0].tests.length).toBe(3);
   const paramsLog = [];
   const resultsLog = [];
   for (let i = 0; i < 3; ++i) {
-    for (const test of suites[i].specs[0].tests) {
+    for (const test of suites[i].suites[0].specs[0].tests) {
       for (const name of Object.keys(test.parameters))
         paramsLog.push(name + '=' + test.parameters[name]);
       resultsLog.push(test.expectedStatus);
@@ -69,7 +69,7 @@ it('should work with parameters', async ({ runInlineTest }) => {
 it('should emit test annotations', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'a.test.js': `
-      it('should emit annotation', (test, parameters) => {
+      test('should emit annotation', (test, parameters) => {
         test.fail(true, 'Fail annotation');
       }, async ({}) => {
         expect(true).toBe(false);
@@ -77,13 +77,13 @@ it('should emit test annotations', async ({ runInlineTest }) => {
     `
   }, { 'list': true });
   expect(result.exitCode).toBe(0);
-  expect(result.report.suites[0].specs[0].tests[0].annotations).toEqual([{ type: 'fail', description: 'Fail annotation' }]);
+  expect(result.report.suites[0].suites[0].specs[0].tests[0].annotations).toEqual([{ type: 'fail', description: 'Fail annotation' }]);
 });
 
 it('should have relative always-posix paths', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'a.test.js': `
-      it('math works!', async ({}) => {
+      test('math works!', async ({}) => {
         expect(1 + 1).toBe(2);
       });
     `
@@ -91,23 +91,23 @@ it('should have relative always-posix paths', async ({ runInlineTest }) => {
   expect(result.exitCode).toBe(0);
   expect(result.report.config.testDir.indexOf(path.win32.sep)).toBe(-1);
   expect(result.report.config.outputDir.indexOf(path.win32.sep)).toBe(-1);
-  expect(result.report.suites[0].specs[0].file).toBe('a.test.js');
-  expect(result.report.suites[0].specs[0].line).toBe(5);
-  expect(result.report.suites[0].specs[0].column).toBe(7);
+  expect(result.report.suites[0].suites[0].specs[0].file).toBe('a.test.js');
+  expect(result.report.suites[0].suites[0].specs[0].line).toBe(5);
+  expect(result.report.suites[0].suites[0].specs[0].column).toBe(7);
 });
 
 it('should emit suite annotations', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'a.test.js': `
-      describe('annotate', test => {
+      test.describe('annotate', test => {
         test.fixme('Fix me!');
       }, () => {
-        it('test', async ({}) => {
+        test('test', async ({}) => {
           expect(true).toBe(false);
         });
       });
     `
   }, { 'list': true });
   expect(result.exitCode).toBe(0);
-  expect(result.report.suites[0].suites[0].specs[0].tests[0].annotations).toEqual([{ type: 'fixme', description: 'Fix me!' }]);
+  expect(result.report.suites[0].suites[0].suites[0].specs[0].tests[0].annotations).toEqual([{ type: 'fixme', description: 'Fix me!' }]);
 });

--- a/test/match-grep.spec.ts
+++ b/test/match-grep.spec.ts
@@ -20,41 +20,41 @@ const { it, expect } = folio;
 it('should grep test name', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'match-grep/a.test.ts': `
-      it('test A', () => {
+      test('test A', () => {
         expect(1 + 1).toBe(2);
       });
 
-      it('test B', () => {
+      test('test B', () => {
         expect(1 + 1).toBe(2);
       });
 
-      it('test C', () => {
+      test('test C', () => {
         expect(1 + 1).toBe(2);
       });
     `,
     'match-grep/b.test.ts': `
-      it('test A', () => {
+      test('test A', () => {
         expect(1 + 1).toBe(2);
       });
 
-      it('test B', () => {
+      test('test B', () => {
         expect(1 + 1).toBe(2);
       });
 
-      it('test C', () => {
+      test('test C', () => {
         expect(1 + 1).toBe(2);
       });
     `,
     'match-grep/c.test.ts': `
-      it('test A', () => {
+      test('test A', () => {
         expect(1 + 1).toBe(2);
       });
 
-      it('test B', () => {
+      test('test B', () => {
         expect(1 + 1).toBe(2);
       });
 
-      it('test C', () => {
+      test('test C', () => {
         expect(1 + 1).toBe(2);
       });
     `,

--- a/test/max-failures.spec.ts
+++ b/test/max-failures.spec.ts
@@ -20,14 +20,14 @@ it('max-failures should work', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'a.spec.js': `
       for (let i = 0; i < 10; ++i) {
-        it('fail_' + i, () => {
+        test('fail_' + i, () => {
           expect(true).toBe(false);
         });
       }
     `,
     'b.spec.js': `
       for (let i = 0; i < 10; ++i) {
-        it('fail_' + i, () => {
+        test('fail_' + i, () => {
           expect(true).toBe(false);
         });
       }
@@ -42,14 +42,14 @@ it('-x should work', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'a.spec.js': `
       for (let i = 0; i < 10; ++i) {
-        it('fail_' + i, () => {
+        test('fail_' + i, () => {
           expect(true).toBe(false);
         });
       }
     `,
     'b.spec.js': `
       for (let i = 0; i < 10; ++i) {
-        it('fail_' + i, () => {
+        test('fail_' + i, () => {
           expect(true).toBe(false);
         });
       }

--- a/test/options.spec.ts
+++ b/test/options.spec.ts
@@ -17,16 +17,26 @@
 import { folio } from './fixtures';
 const { it, expect } = folio;
 
-it('should be able to redefine config', async ({ runInlineTest }) => {
+it('should create two suites with different options', async ({ runInlineTest }) => {
   const result = await runInlineTest({
+    'fixtures.ts': `
+      async function getFoo({ testInfo }, run) {
+        await run(testInfo.options.foo);
+      }
+      export const toBeRenamed = { testFixtures: { getFoo } };
+    `,
     'a.test.ts': `
-      config.timeout = 12345;
-      test('pass', async ({ testInfo }) => {
-        expect(testInfo.timeout).toBe(12345);
+      const test1 = createTest({ foo: 'bar' });
+      test1('test1', ({ testInfo, getFoo }) => {
+        expect(testInfo.options.foo).toBe('bar');
+        expect(getFoo).toBe('bar');
+      });
+      const test2 = createTest({ foo: 'baz' });
+      test2('test2', ({ testInfo, getFoo }) => {
+        expect(getFoo).toBe('baz');
       });
     `
   });
-
   expect(result.exitCode).toBe(0);
-  expect(result.passed).toBe(1);
+  expect(result.passed).toBe(2);
 });

--- a/test/output-path.spec.ts
+++ b/test/output-path.spec.ts
@@ -20,7 +20,7 @@ const { it, expect } = folio;
 it('should include repeat token', async ({runInlineTest}) => {
   const result = await runInlineTest({
     'a.spec.js': `
-      it('test', ({testInfo}) => {
+      test('test', ({testInfo}) => {
         if (testInfo.repeatEachIndex)
           expect(testInfo.outputPath('')).toContain('repeat' + testInfo.repeatEachIndex);
         else
@@ -35,7 +35,7 @@ it('should include repeat token', async ({runInlineTest}) => {
 it('should include retry token', async ({runInlineTest}) => {
   const result = await runInlineTest({
     'a.spec.js': `
-      it('test', ({testInfo}) => {
+      test('test', ({testInfo}) => {
         expect(testInfo.outputPath('')).toContain('retry' + testInfo.retry);
         expect(testInfo.retry).toBe(2);
       });

--- a/test/override-timeout.spec.ts
+++ b/test/override-timeout.spec.ts
@@ -19,28 +19,29 @@ const { it, expect } = folio;
 
 it('should consider dynamically set value', async ({ runInlineTest }) => {
   const result = await runInlineTest({
-    'fixture.js': `
+    'fixtures.js': `
 		  config.timeout = 100;
+      exports.toBeRenamed = {};
     `,
     'a.test.js': `
-      require('./fixture.js');
-      it('pass', ({ testInfo }) => {
+      test('pass', ({ testInfo }) => {
         expect(testInfo.timeout).toBe(100);
       })
     `
   });
+  expect(result.report.config.timeout).toBe(100);
   expect(result.exitCode).toBe(0);
   expect(result.passed).toBe(1);
 });
 
 it('should prioritize value set via command line', async ({ runInlineTest }) => {
   const result = await runInlineTest({
-    'fixture.js': `
-		  config.timeout = 100;
+    'fixtures.js': `
+      config.timeout = 100;
+      exports.toBeRenamed = {};
     `,
     'a.test.js': `
-      require('./fixture.js');
-      it('pass', ({ testInfo }) => {
+      test('pass', ({ testInfo }) => {
         expect(testInfo.timeout).toBe(1000);
       })
     `

--- a/test/parameters.spec.ts
+++ b/test/parameters.spec.ts
@@ -26,7 +26,7 @@ it('should run with each configuration', async ({ runInlineTest }) => {
       } };
     `,
     'a.test.ts': `
-      it('runs 6 times', (test, parameters) => {
+      test('runs 6 times', (test, parameters) => {
         test.skip(parameters.foo === 'foo1' && parameters.bar === 'bar1');
       }, async ({ foo, bar }) => {
         expect(foo).toContain('foo');
@@ -38,7 +38,7 @@ it('should run with each configuration', async ({ runInlineTest }) => {
 
   expect(result.exitCode).toBe(0);
   expect(result.passed).toBe(5);  // 6 total, one skipped
-  const parametersList = result.report.suites[0].specs[0].tests.map(r => r.parameters);
+  const parametersList = result.report.suites[0].suites[0].specs[0].tests.map(r => r.parameters);
   for (const foo of ['foo1', 'foo2', 'foo3']) {
     for (const bar of ['bar1', 'bar2']) {
       expect(parametersList.find(o => o.foo === foo && o.bar === bar)).toBeTruthy();
@@ -61,7 +61,7 @@ it('should throw on duplicate parameters', async ({ runInlineTest }) => {
       } };
     `,
     'a.spec.ts': `
-      it('success', async ({}) => {
+      test('success', async ({}) => {
       });
     `
   });
@@ -78,7 +78,7 @@ it('should use kebab for CLI name', async ({ runInlineTest }) => {
       } };
     `,
     'a.test.ts': `
-      it('test', async ({ fooCamelCase }) => {
+      test('test', async ({ fooCamelCase }) => {
         expect(fooCamelCase).toBe('kebab-value');
       });
     `
@@ -95,7 +95,7 @@ it('should show parameters descriptions', async ({ runInlineTest }) => {
       } };
     `,
     'a.test.ts': `
-      it('should work', () => {});
+      test('should work', () => {});
     `
   }, { 'help': true });
   expect(result.output).toContain(`-p, --param browserName=<value>`);
@@ -114,7 +114,7 @@ it('should support integer parameter', async ({ runInlineTest }) => {
       } };
     `,
     'a.test.ts': `
-      it('success', async ({integer}) => {
+      test('success', async ({integer}) => {
         expect(integer).toBe(6);
       });
     `
@@ -130,7 +130,7 @@ it('should support boolean parameter', async ({ runInlineTest }) => {
       } };
     `,
     'a.test.ts': `
-      it('success', async ({bool}) => {
+      test('success', async ({bool}) => {
         expect(bool).toBe(true);
       });
     `
@@ -146,7 +146,7 @@ it('should generate tests from CLI', async ({ runInlineTest }) => {
       } };
     `,
     'a.test.ts': `
-      it('success', async ({bool}) => {
+      test('success', async ({bool}) => {
         expect(bool).toBe(true);
       });
     `
@@ -173,13 +173,13 @@ it('tests respect automatic fixture parameters', async ({ runInlineTest }) => {
       };
     `,
     'a.test.js': `
-      it('test 1', async ({}) => {
+      test('test 1', async ({}) => {
         expect(1).toBe(1);
       });
     `
   });
   expect(result.exitCode).toBe(0);
-  expect(result.report.suites[0].specs[0].tests[0].parameters).toEqual({ param: 'value' });
+  expect(result.report.suites[0].suites[0].specs[0].tests[0].parameters).toEqual({ param: 'value' });
 });
 
 it('should not duplicate parameters in configuration', async ({ runInlineTest }) => {
@@ -201,7 +201,7 @@ it('should not duplicate parameters in configuration', async ({ runInlineTest })
       };
     `,
     'a.test.ts': `
-      it('runs 3 times', async ({ f1, f2 }) => {
+      test('runs 3 times', async ({ f1, f2 }) => {
         expect(f1).toContain('foo');
         expect(f2).toContain('foo');
         expect(f1).toBe(f2);
@@ -226,12 +226,12 @@ it('should generate tests when parameters are in beforeEach', async ({ runInline
       };
     `,
     'a.test.js': `
-      describe('suite', () => {
+      test.describe('suite', () => {
         let fooValue;
-        beforeEach(({ foo }) => {
+        test.beforeEach(({ foo }) => {
           fooValue = foo;
         });
-        it('runs 3 times', async ({}) => {
+        test('runs 3 times', async ({}) => {
           console.log(fooValue);
         });
       });

--- a/test/repeat-each.spec.ts
+++ b/test/repeat-each.spec.ts
@@ -20,7 +20,7 @@ const { it, expect } = folio;
 it('should get top level stdio', async ({runInlineTest}) => {
   const result = await runInlineTest({
     'a.spec.js': `
-      it('test', ({testInfo}) => {
+      test('test', ({testInfo}) => {
         console.log('REPEAT ' + testInfo.repeatEachIndex);
         expect(1).toBe(1);
       });

--- a/test/retry.spec.ts
+++ b/test/retry.spec.ts
@@ -20,7 +20,7 @@ const { it, expect } = folio;
 it('should retry failures', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'retry-failures.spec.js': `
-      it('flake', async ({ testInfo }) => {
+      test('flake', async ({ testInfo }) => {
         // Passes on the second run.
         expect(testInfo.retry).toBe(1);
       });
@@ -40,7 +40,7 @@ it('should retry failures', async ({ runInlineTest }) => {
 it('should retry timeout', async ({ runInlineTest }) => {
   const { exitCode, passed, failed, output } = await runInlineTest({
     'one-timeout.spec.js': `
-      it('timeout', async () => {
+      test('timeout', async () => {
         await new Promise(f => setTimeout(f, 10000));
       });
     `
@@ -54,7 +54,7 @@ it('should retry timeout', async ({ runInlineTest }) => {
 it('should fail on unexpected pass with retries', async ({ runInlineTest }) => {
   const { exitCode, failed, output } = await runInlineTest({
     'unexpected-pass.spec.js': `
-      it('succeeds', test => test.fail(), () => {
+      test('succeeds', test => test.fail(), () => {
         expect(1 + 1).toBe(2);
       });
     `
@@ -67,7 +67,7 @@ it('should fail on unexpected pass with retries', async ({ runInlineTest }) => {
 it('should not retry unexpected pass', async ({ runInlineTest }) => {
   const { exitCode, passed, failed, output } = await runInlineTest({
     'unexpected-pass.spec.js': `
-      it('succeeds', test => test.fail(), () => {
+      test('succeeds', test => test.fail(), () => {
         expect(1 + 1).toBe(2);
       });
     `
@@ -81,11 +81,11 @@ it('should not retry unexpected pass', async ({ runInlineTest }) => {
 it('should not retry expected failure', async ({ runInlineTest }) => {
   const { exitCode, passed, failed, output } = await runInlineTest({
     'expected-failure.spec.js': `
-      it('fails', test => test.fail(), () => {
+      test('fails', test => test.fail(), () => {
         expect(1 + 1).toBe(3);
       });
 
-      it('non-empty remaining',() => {
+      test('non-empty remaining',() => {
         expect(1 + 1).toBe(2);
       });
     `
@@ -99,7 +99,7 @@ it('should not retry expected failure', async ({ runInlineTest }) => {
 it('should retry unhandled rejection', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'unhandled-rejection.spec.js': `
-      it('unhandled rejection', async () => {
+      test('unhandled rejection', async () => {
         setTimeout(() => {
           throw new Error('Unhandled rejection in the test');
         });

--- a/test/stdio.spec.ts
+++ b/test/stdio.spec.ts
@@ -21,7 +21,7 @@ it('should get top level stdio', async ({runInlineTest}) => {
     'a.spec.js': `
       console.log('%% top level stdout');
       console.error('%% top level stderr');
-      it('is a test', () => {
+      test('is a test', () => {
         console.log('%% stdout in a test');
         console.error('%% stderr in a test');
       });
@@ -50,7 +50,7 @@ it('should get stdio from worker fixture teardown', async ({runInlineTest}) => {
       };
     `,
     'a.spec.js': `
-      it('is a test', async ({fixture}) => {});
+      test('is a test', async ({fixture}) => {});
     `
   });
   expect(result.output.split('\n').filter(x => x.startsWith('%%'))).toEqual([

--- a/test/test-ignore.spec.ts
+++ b/test/test-ignore.spec.ts
@@ -19,13 +19,13 @@ const { it, expect } = folio;
 
 const tests = {
   'a.test.ts': `
-    it('pass', ({}) => {});
+    test('pass', ({}) => {});
   `,
   'b.test.ts': `
-    it('pass', ({}) => {});
+    test('pass', ({}) => {});
   `,
   'c.test.ts': `
-    it('pass', ({}) => {});
+    test('pass', ({}) => {});
   `
 };
 
@@ -44,16 +44,16 @@ it('should ignore a test', async ({ runInlineTest }) => {
 it('should ignore a folder', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'a.test.ts': `
-      it('pass', ({}) => {});
+      test('pass', ({}) => {});
     `,
     'folder/a.test.ts': `
-      it('pass', ({}) => {});
+      test('pass', ({}) => {});
     `,
     'folder/b.test.ts': `
-      it('pass', ({}) => {});
+      test('pass', ({}) => {});
     `,
     'folder/c.test.ts': `
-      it('pass', ({}) => {});
+      test('pass', ({}) => {});
     `
   }, { 'test-ignore': 'folder/**' });
   expect(result.passed).toBe(1);
@@ -63,16 +63,16 @@ it('should ignore a folder', async ({ runInlineTest }) => {
 it('should ignore a node_modules', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'a.test.ts': `
-      it('pass', ({}) => {});
+      test('pass', ({}) => {});
     `,
     'node_modules/a.test.ts': `
-      it('pass', ({}) => {});
+      test('pass', ({}) => {});
     `,
     'node_modules/b.test.ts': `
-      it('pass', ({}) => {});
+      test('pass', ({}) => {});
     `,
     'folder/c.test.ts': `
-      it('pass', ({}) => {});
+      test('pass', ({}) => {});
     `
   });
   expect(result.passed).toBe(2);

--- a/test/test-info-fixture.spec.ts
+++ b/test/test-info-fixture.spec.ts
@@ -20,10 +20,10 @@ const { it } = folio;
 it('should work directly', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'a.test.js': `
-      it('test 1', async ({testInfo}) => {
+      test('test 1', async ({testInfo}) => {
         expect(testInfo.title).toBe('test 1');
       });
-      it('test 2', async ({testInfo}) => {
+      test('test 2', async ({testInfo}) => {
         expect(testInfo.title).toBe('test 2');
       });
     `,
@@ -42,10 +42,10 @@ it('should work via fixture', async ({ runInlineTest }) => {
       };
     `,
     'a.test.js': `
-      it('test 1', async ({title}) => {
+      test('test 1', async ({title}) => {
         expect(title).toBe('test 1');
       });
-      it('test 2', async ({title}) => {
+      test('test 2', async ({title}) => {
         expect(title).toBe('test 2');
       });
     `,

--- a/test/test-output-dir-fixture.spec.ts
+++ b/test/test-output-dir-fixture.spec.ts
@@ -20,7 +20,7 @@ const { it } = folio;
 it('should work and remove empty dir', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'my-test.spec.js': `
-      it('test 1', async ({testInfo}) => {
+      test('test 1', async ({testInfo}) => {
         if (testInfo.retry) {
           expect(testInfo.outputPath('foo', 'bar')).toContain(require('path').join('my-test', 'test-1-retry1', 'foo', 'bar'));
         } else {

--- a/test/timeout.spec.ts
+++ b/test/timeout.spec.ts
@@ -29,7 +29,7 @@ it('should run fixture tear down on timeout', async ({ runInlineTest }) => {
       };
     `,
     'c.spec.ts': `
-      it('works', async ({ foo }) => {
+      test('works', async ({ foo }) => {
         await new Promise(f => setTimeout(f, 100000));
       });
     `

--- a/test/types.spec.ts
+++ b/test/types.spec.ts
@@ -42,7 +42,7 @@ it('should be able to import/export fixtures', async ({ runInlineTest }) => {
       export const toBeRenamed = { testFixtures: { testTypeOnly }, workerFixtures: { workerTypeOnly } };
     `,
     'import-fixtures-both.spec.ts': `
-      it('ensure that overrides work', async ({ testTypeOnly, workerTypeOnly, testWrap, workerWrap }) => {
+      test('ensure that overrides work', async ({ testTypeOnly, workerTypeOnly, testWrap, workerWrap }) => {
         expect(testWrap).toBe('testWrap');
         expect(workerWrap).toBe(42);
         expect(testTypeOnly).toBe('testTypeOnly');

--- a/test/worker-index.spec.ts
+++ b/test/worker-index.spec.ts
@@ -22,7 +22,7 @@ it('should run in parallel', async ({ runInlineTest }) => {
     '1.spec.ts': `
       import * as fs from 'fs';
       import * as path from 'path';
-      it('succeeds', async ({ testWorkerIndex }) => {
+      test('succeeds', async ({ testWorkerIndex }) => {
         expect(testWorkerIndex).toBe(0);
         // First test waits for the second to start to work around the race.
         while (true) {
@@ -35,7 +35,7 @@ it('should run in parallel', async ({ runInlineTest }) => {
     '2.spec.ts': `
       import * as fs from 'fs';
       import * as path from 'path';
-      it('succeeds', async ({ testWorkerIndex }) => {
+      test('succeeds', async ({ testWorkerIndex }) => {
         // First test waits for the second to start to work around the race.
         fs.mkdirSync(config.outputDir, { recursive: true });
         fs.writeFileSync(path.join(config.outputDir, 'parallel-index.txt'), 'TRUE');
@@ -61,11 +61,11 @@ it('should reuse worker for the same parameters', async ({ runInlineTest }) => {
       export const toBeRenamed = { workerFixtures: { worker1, worker2 } };
     `,
     'a.test.js': `
-      it('succeeds', async ({ worker1, testWorkerIndex }) => {
+      test('succeeds', async ({ worker1, testWorkerIndex }) => {
         expect(testWorkerIndex).toBe(0);
       });
 
-      it('succeeds', async ({ worker2, testWorkerIndex }) => {
+      test('succeeds', async ({ worker2, testWorkerIndex }) => {
         expect(testWorkerIndex).toBe(0);
       });
     `,
@@ -82,11 +82,11 @@ it('should not reuse worker for different parameters', async ({ runInlineTest })
       };
     `,
     'a.test.js': `
-      it('succeeds', async ({ testWorkerIndex }) => {
+      test('succeeds', async ({ testWorkerIndex }) => {
         expect(testWorkerIndex).toBe(0);
       });
 
-      it('succeeds', async ({ param, testWorkerIndex }) => {
+      test('succeeds', async ({ param, testWorkerIndex }) => {
         expect(testWorkerIndex).toBe(1);
       });
     `,


### PR DESCRIPTION
The following syntax is used now:
```ts
import { createTest } from 'folio';
const test = createTest({ option: 'value' });
test('should work', () => {});
```