### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,7 +400,7 @@ fixtures.saveLogsOnFailure.init(async ({ testInfo }, runTest) => {
   await runTest();
   if (testInfo.status !== testInfo.expectedStatus)
     fs.writeFileSync(testInfo.outputPath('logs.txt'), logs.join('\n'), 'utf8');
-}, { auto: true );
+}, { auto: true });
 
 export const folio = fixtures.build();
 ```


### PR DESCRIPTION
This fixes a small typo, but I also could not get this example to run. 

My goal was to make a small script that would programatically run the tests, here was my best guess

```ts
import { folio as base } from "folio";
import * as debug from "debug";
import * as fs from "fs";

const fixtures = base.extend<{
  headful: true;
  location: "examples/vscode-04.ts";
}>();

export const folio = fixtures.build();
```

The reason I want to do this is that we have some setup to also record the tests with Replay and it'd be nice to wrap this setup in a runner file