### PR TITLE
chore(reporters): enhance list reporter on bots

### DIFF
--- a/src/reporters/list.ts
+++ b/src/reporters/list.ts
@@ -31,7 +31,8 @@ class ListReporter extends BaseReporter {
 
   onTestBegin(test: Test) {
     super.onTestBegin(test);
-    process.stdout.write('    ' + colors.gray(test.spec.fullTitle() + ': ') + '\n');
+    if (process.stdout.isTTY)
+      process.stdout.write('    ' + colors.gray(test.spec.fullTitle() + ': ') + '\n');
     this._testRows.set(test, this._lastRow++);
   }
 
@@ -48,19 +49,24 @@ class ListReporter extends BaseReporter {
       if (result.status === test.expectedStatus)
         text = '\u001b[2K\u001b[0G' + colors.green(statusMark) + colors.gray(spec.fullTitle()) + duration;
       else
-        text = '\u001b[2K\u001b[0G' + colors.red(`  ${++this._failure}) ` + spec.fullTitle()) + duration;
+        text = '\u001b[2K\u001b[0G' + colors.red(`${statusMark}${++this._failure}) ` + spec.fullTitle()) + duration;
     }
 
     const testRow = this._testRows.get(test);
     // Go up if needed
-    if (testRow !== this._lastRow)
+    if (process.stdout.isTTY && testRow !== this._lastRow)
       process.stdout.write(`\u001B[${this._lastRow - testRow}A`);
     // Erase line
-    process.stdout.write('\u001B[2K');
+    if (process.stdout.isTTY)
+      process.stdout.write('\u001B[2K');
     process.stdout.write(text);
     // Go down if needed.
-    if (testRow !== this._lastRow)
-      process.stdout.write(`\u001B[${this._lastRow - testRow}E`);
+    if (testRow !== this._lastRow) {
+      if (process.stdout.isTTY)
+        process.stdout.write(`\u001B[${this._lastRow - testRow}E`);
+      else
+        process.stdout.write('\n');
+    }
   }
 
   onEnd() {


### PR DESCRIPTION
This change fixes two issues:
a) not using ansi cursor navigation when no TTY is available. This
improves usage especially on bots like GitHub Actions. (was before broken and showed on-going and success/failed text in the same line)
Fixes #122
b) use unicode '✘' character for failed test to be consistent with the
unicode checkmark for passed tests

See here for the changed output regarding b)

 Before:

```
  ✓ foo (2s)
  ✓ bar (2s)
  1) foo bar (1s)
  ✓ foobar (2s)
```

After:

```
  ✓ foo (2s)
  ✓ bar (2s)
  ✘ 1) foo bar (1s)
  ✓ foobar (2s)
```

Tested the follow test-cases manually:
- with tty
- with tty and failing test
- without tty
- without tty and failing test