### PR TITLE
fix: sort out output and snapshot paths

### DIFF
--- a/src/spec.ts
+++ b/src/spec.ts
@@ -18,7 +18,7 @@ import { expect } from './expect';
 import { currentTestInfo } from './globals';
 import { Spec, Suite } from './test';
 import { callLocation, errorWithCallLocation, interpretCondition } from './util';
-import { Config, Env, RunWithConfig, TestInfo, WorkerInfo } from './types';
+import { Config, Env, RunWithConfig, TestInfo, TestType, WorkerInfo } from './types';
 
 Error.stackTraceLimit = 15;
 
@@ -32,6 +32,7 @@ export type RunListDescription = {
   fileSuites: Map<string, Suite>;
   env: Env<any>;
   config: RunWithConfig;
+  testType: TestType<any, any>;
 };
 
 export const configFile: {
@@ -190,6 +191,7 @@ export function newTestTypeImpl(): any {
       env: mergeEnvs(envs),
       alias,
       config: { timeout: options.timeout },
+      testType: test,
     });
   };
   return test;

--- a/src/types.ts
+++ b/src/types.ts
@@ -73,7 +73,7 @@ export interface TestInfo extends WorkerInfo {
   data: any;
 
   // Paths
-  relativeArtifactsPath: string;
+  snapshotPathSegment: string;
   snapshotPath: (...pathSegments: string[]) => string;
   outputPath: (...pathSegments: string[]) => string;
 }

--- a/test/test-output-dir.spec.ts
+++ b/test/test-output-dir.spec.ts
@@ -22,7 +22,7 @@ it('should work and remove empty dir', async ({ runInlineTest }) => {
     'my-test.spec.js': `
       test('test 1', async ({}, testInfo) => {
         if (testInfo.retry) {
-          expect(testInfo.outputPath('foo', 'bar')).toContain(require('path').join('my-test', 'test-1-retry1', 'foo', 'bar'));
+          expect(testInfo.outputPath('foo', 'bar')).toContain(require('path').join('my-test', 'test-1', 'retry1', 'foo', 'bar'));
         } else {
           expect(testInfo.outputPath()).toContain(require('path').join('my-test', 'test-1'));
           expect(testInfo.outputPath('foo', 'bar')).toContain(require('path').join('my-test', 'test-1', 'foo', 'bar'));
@@ -32,7 +32,7 @@ it('should work and remove empty dir', async ({ runInlineTest }) => {
           throw new Error('Give me a retry');
       });
     `,
-  }, { retries: 10 });
+  }, { retries: 1 });
   expect(result.exitCode).toBe(0);
 
   expect(result.results[0].status).toBe('failed');
@@ -42,4 +42,62 @@ it('should work and remove empty dir', async ({ runInlineTest }) => {
 
   expect(result.results[1].status).toBe('passed');
   expect(result.results[1].retry).toBe(1);
+});
+
+it('should include runWith alias', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'folio.config.ts': `
+      class Env {
+        constructor(snapshotPathSegment) {
+          this._snapshotPathSegment = snapshotPathSegment;
+        }
+        async beforeEach(testInfo) {
+          testInfo.snapshotPathSegment = this._snapshotPathSegment;
+          return {};
+        }
+      }
+      export const test = folio.newTestType();
+      export const test2 = folio.newTestType();
+      test.runWith('foo', new Env('snapshots1'));
+      test.runWith('foo', new Env('snapshots2'));
+      test2.runWith('foo', new Env('snapshots1'));
+      test2.runWith(new Env('snapshots1'));
+    `,
+    'my-test.spec.js': `
+      const { test, test2 } = require('./folio.config');
+      test('test 1', async ({}, testInfo) => {
+        console.log(testInfo.outputPath('bar.txt').replace(/\\\\/g, '/'));
+        console.log(testInfo.snapshotPath('bar.txt').replace(/\\\\/g, '/'));
+        if (testInfo.retry !== 1)
+          throw new Error('Give me a retry');
+      });
+      test2('test 2', async ({}, testInfo) => {
+        console.log(testInfo.outputPath('bar.txt').replace(/\\\\/g, '/'));
+        console.log(testInfo.snapshotPath('bar.txt').replace(/\\\\/g, '/'));
+      });
+    `,
+  }, { retries: 1 });
+  expect(result.exitCode).toBe(0);
+  expect(result.results[0].status).toBe('failed');
+  expect(result.results[1].status).toBe('passed');
+
+  // test1, run with first env
+  expect(result.output).toContain('test-results/my-test/test-1/foo1/bar.txt');
+  expect(result.output).toContain('__snapshots__/my-test/test-1/snapshots1/bar.txt');
+  expect(result.output).toContain('test-results/my-test/test-1/foo1-retry1/bar.txt');
+  expect(result.output).toContain('__snapshots__/my-test/test-1/snapshots1/bar.txt');
+
+  // test1, run with second env
+  expect(result.output).toContain('test-results/my-test/test-1/foo2/bar.txt');
+  expect(result.output).toContain('__snapshots__/my-test/test-1/snapshots2/bar.txt');
+  expect(result.output).toContain('test-results/my-test/test-1/foo2-retry1/bar.txt');
+  expect(result.output).toContain('__snapshots__/my-test/test-1/snapshots2/bar.txt');
+
+  // test2, run with env and alias
+  expect(result.output).toContain('test-results/my-test/test-2/foo/bar.txt');
+  expect(result.output).toContain('__snapshots__/my-test/test-2/snapshots1/bar.txt');
+
+  // test2, run with env but no alias
+  expect(result.output).toContain('test-results/my-test/test-2/bar.txt');
+  expect(result.output).toContain('__snapshots__/my-test/test-2/snapshots1/bar.txt');
 });


### PR DESCRIPTION
Output defaults to the alias or alias-<number> (for reused aliases),
includes 'retry<number>' and 'repeat<number>' when needed.

Snapshot defaults to empty, unless `testInfo.snapshotPathSegement'
is assigned to some other value.