### PR TITLE
feat(globalSetup): run globalSetup before requiring any test files

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,7 +311,6 @@ Depending on the configuration and failures, Folio might use different number of
 
 Environment and hooks receive `workerInfo` in the `beforeAll` and `afterAll` calls. The following information is accessible from the `workerInfo`:
 - `config` - [Configuration object](#configuration-object).
-- `globalSetupResult` - The value returned by the [global setup function](#global-setup-and-teardown).
 - `workerIndex: number` - A unique sequential index assigned to the worker process.
 
 Consider an example where we run a new http server per worker process, and use `workerIndex` to produce a unique port number:
@@ -485,7 +484,7 @@ fooTest('a smoke test', async ({ foo }) => {
 
 ### Global setup and teardown
 
-To set something up once before running all tests, use `globalSetup` hook in the [configuration file](#writing-a-configuration-file). Similarly, use `globalTeardown` to run something once after all the tests. `globalSetup` hook can pass json-serializable data to the tests - it will be available as [`workerInfo.globalSetupResult`](#workerinfo).
+To set something up once before running all tests, use `globalSetup` hook in the [configuration file](#writing-a-configuration-file). Similarly, use `globalTeardown` to run something once after all the tests.
 
 ```ts
 // folio.config.ts
@@ -499,7 +498,7 @@ let server: http.Server;
 folio.globalSetup(async () => {
   server = http.createServer(app);
   await new Promise(done => server.listen(done));
-  return server.address().port; // Expose port to the tests.
+  process.env.SERVER_PORT = String(server.address().port); // Expose port to the tests.
 });
 
 folio.globalTeardown(async () => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -113,8 +113,6 @@ async function runTests(command: any) {
   const testFileFilter: string[] = command.args;
   const allFiles = await collectFiles(testDir);
   const testFiles = filterFiles(testDir, allFiles, testFileFilter, createMatcher(loader.config().testMatch), createMatcher(loader.config().testIgnore));
-  for (const file of testFiles)
-    loader.loadTestFile(file);
 
   if (command.reporter && command.reporter.length) {
     const reporterList: string[] = command.reporter.split(',');
@@ -131,14 +129,9 @@ async function runTests(command: any) {
     }));
   }
 
-  const runner = new Runner(loader, command.tag && command.tag.length ? command.tag : undefined);
-
-  if (command.list) {
-    runner.list();
-    return;
-  }
-
-  const result = await runner.run();
+  const runner = new Runner(loader);
+  const tagFilter = command.tag && command.tag.length ? command.tag : undefined;
+  const result = await runner.run(!!command.list, testFiles, tagFilter);
   if (result === 'sigint')
     process.exit(130);
 

--- a/src/dispatcher.ts
+++ b/src/dispatcher.ts
@@ -43,8 +43,6 @@ export class Dispatcher {
   private _hasWorkerErrors = false;
   private _isStopped = false;
   private _failureCount = 0;
-  private _didRunGlobalSetup = false;
-  _globalSetupResult: any = undefined;
 
   constructor(loader: Loader, suite: Suite, reporter: Reporter) {
     this._loader = loader;
@@ -136,10 +134,6 @@ export class Dispatcher {
   }
 
   async run() {
-    if (this._loader.globalSetup) {
-      this._didRunGlobalSetup = true;
-      this._globalSetupResult = await this._loader.globalSetup();
-    }
     // Loop in case job schedules more jobs
     while (this._queue.length && !this._isStopped)
       await this._dispatchQueue();
@@ -307,8 +301,6 @@ export class Dispatcher {
         worker.stop();
       await result;
     }
-    if (this._didRunGlobalSetup && this._loader.globalTeardown)
-      await this._loader.globalTeardown();
   }
 
   private _reportTestEnd(test: Test, result: TestResult, status: TestStatus) {
@@ -369,7 +361,6 @@ class Worker extends EventEmitter {
       workerIndex: this.index,
       repeatEachIndex: entry.repeatEachIndex,
       runListIndex: entry.runListIndex,
-      globalSetupResult: this.runner._globalSetupResult,
       loader: this.runner._loader.serialize(),
     };
     this.process.send({ method: 'init', params });

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -21,7 +21,6 @@ export type WorkerInitParams = {
   workerIndex: number;
   repeatEachIndex: number;
   runListIndex: number;
-  globalSetupResult: any;
   loader: {
     configs: (string | Config)[];
   };

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -18,16 +18,12 @@ import { installTransform } from './transform';
 import { Config, FullConfig, Reporter } from './types';
 import { prependErrorMessage } from './util';
 import { configFile, setCurrentFile, RunListDescription, setLoadingConfigFile } from './spec';
-import { Test } from './test';
 
 type SerializedLoaderData = {
   configs: (string | Config)[];
 };
 
 export class Loader {
-  globalSetup?: () => any;
-  globalTeardown?: () => any;
-
   private _mergedConfig: FullConfig;
   private _layeredConfigs: { config: Config, source?: string }[] = [];
 
@@ -51,8 +47,6 @@ export class Loader {
       require(file);
       this.addConfig(configFile.config || {});
       this._layeredConfigs[this._layeredConfigs.length - 1].source = file;
-      this.globalSetup = configFile.globalSetup;
-      this.globalTeardown = configFile.globalTeardown;
     } catch (e) {
       // Drop the stack.
       throw new Error(e.message);
@@ -93,6 +87,14 @@ export class Loader {
 
   reporters(): Reporter[] {
     return configFile.reporters;
+  }
+
+  globalSetups(): (() => any)[] {
+    return configFile.globalSetups;
+  }
+
+  globalTeardowns(): (() => any)[] {
+    return configFile.globalTeardowns;
   }
 
   serialize(): SerializedLoaderData {

--- a/src/spec.ts
+++ b/src/spec.ts
@@ -38,11 +38,11 @@ export type RunListDescription = {
 
 export const configFile: {
   config?: Config,
-  globalSetup?: () => any,
-  globalTeardown?: () => any,
+  globalSetups: (() => any)[],
+  globalTeardowns: (() => any)[],
   runLists: RunListDescription[],
   reporters: Reporter[],
-} = { runLists: [], reporters: [] };
+} = { globalSetups: [], globalTeardowns: [], runLists: [], reporters: [] };
 
 let loadingConfigFile = false;
 export function setLoadingConfigFile(loading: boolean) {
@@ -212,14 +212,18 @@ export function setConfig(config: Config) {
 
 export function globalSetup(globalSetupFunction: () => any) {
   if (typeof globalSetupFunction !== 'function')
-    throw errorWithCallLocation(`globalSetup takes a single function argument.`);
-  configFile.globalSetup = globalSetupFunction;
+    throw errorWithCallLocation(`globalSetup() takes a single function argument.`);
+  if (!loadingConfigFile)
+    throw errorWithCallLocation(`globalSetup() can only be called in a configuration file.`);
+  configFile.globalSetups.push(globalSetupFunction);
 }
 
 export function globalTeardown(globalTeardownFunction: () => any) {
   if (typeof globalTeardownFunction !== 'function')
-    throw errorWithCallLocation(`globalTeardown takes a single function argument.`);
-  configFile.globalTeardown = globalTeardownFunction;
+    throw errorWithCallLocation(`globalTeardown() takes a single function argument.`);
+  if (!loadingConfigFile)
+    throw errorWithCallLocation(`globalTeardown() can only be called in a configuration file.`);
+  configFile.globalTeardowns.push(globalTeardownFunction);
 }
 
 export function setReporters(reporters: Reporter[]) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -61,7 +61,6 @@ export type TestStatus = 'passed' | 'failed' | 'timedOut' | 'skipped';
 export interface WorkerInfo {
   config: FullConfig;
   workerIndex: number;
-  globalSetupResult: any;
 }
 
 export interface TestInfo extends WorkerInfo, TestModifier {

--- a/src/workerRunner.ts
+++ b/src/workerRunner.ts
@@ -102,7 +102,6 @@ export class WorkerRunner extends EventEmitter {
     this._workerInfo = {
       workerIndex: this._params.workerIndex,
       config: { ...this._config },
-      globalSetupResult: this._params.globalSetupResult,
     };
 
     if (this._isStopped)

--- a/test/config.ts
+++ b/test/config.ts
@@ -264,7 +264,7 @@ export function stripAscii(str: string): string {
 folio.setConfig({
   testDir: __dirname,
   testIgnore: 'assets/**',
-  timeout: 10000,
+  timeout: 20000,
   forbidOnly: !!process.env.CI,
 });
 


### PR DESCRIPTION
 - Also allow multiple `globalSetup`/`globalTeardown` calls.
- Throw when `globalSetup`/`globalTeardown` is called outside of config file.