### PR TITLE
feat: support test.extend and test.declare

### DIFF
--- a/src/dispatcher.ts
+++ b/src/dispatcher.ts
@@ -83,9 +83,9 @@ export class Dispatcher {
 
     if (process.stdout.isTTY) {
       const workers = new Set<string>();
-      suite.findSpec(test => {
-        for (const variant of test.tests)
-          workers.add(test.file + variant._workerHash);
+      suite.findSpec(spec => {
+        for (const test of spec.tests)
+          workers.add(spec.file + test._variation.workerHash);
       });
       console.log();
       const jobs = Math.min(this._loader.config().workers, workers.size);
@@ -98,10 +98,10 @@ export class Dispatcher {
     for (const suite of this._suite.suites) {
       for (const spec of suite._allSpecs()) {
         for (const test of spec.tests) {
-          let entriesByFile = entriesByWorkerHashAndFile.get(test._workerHash);
+          let entriesByFile = entriesByWorkerHashAndFile.get(test._variation.workerHash);
           if (!entriesByFile) {
             entriesByFile = new Map();
-            entriesByWorkerHashAndFile.set(test._workerHash, entriesByFile);
+            entriesByWorkerHashAndFile.set(test._variation.workerHash, entriesByFile);
           }
           let entry = entriesByFile.get(spec.file);
           if (!entry) {
@@ -110,9 +110,9 @@ export class Dispatcher {
                 entries: [],
                 file: spec.file,
               },
-              repeatEachIndex: test._repeatEachIndex,
-              runListIndex: test._runList.index,
-              hash: test._workerHash,
+              repeatEachIndex: test._variation.repeatEachIndex,
+              runListIndex: test._variation.runListIndex,
+              hash: test._variation.workerHash,
             };
             entriesByFile.set(spec.file, entry);
           }

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,8 +27,8 @@ export * from './types';
 export { expect } from './expect';
 export { setConfig, setReporters, globalSetup, globalTeardown } from './spec';
 
-export function newTestType<TestArgs = {}, TestOptions = {}>(): TestType<TestArgs, TestOptions> {
-  return newTestTypeImpl();
+export function newTestType<TestArgs = {}, TestOptions = {}>(): TestType<TestArgs, TestOptions, TestArgs> {
+  return newTestTypeImpl([]);
 }
 
 export function merge<TestArgs>(env: Env<TestArgs>): Env<TestArgs>;

--- a/test/env.spec.ts
+++ b/test/env.spec.ts
@@ -184,12 +184,12 @@ test('multiple envs for a single test type should work', async ({ runInlineTest 
   const { passed } = await runInlineTest({
     'folio.config.ts': `
       class Env1 {
-        async beforeEach(testInfo) {
+        async beforeEach(args, testInfo) {
           return { env1: testInfo.title + '-env1' };
         }
       }
       class Env2 {
-        async beforeEach(testInfo) {
+        async beforeEach(args, testInfo) {
           return { env2: testInfo.title + '-env2' };
         }
       }

--- a/test/options.spec.ts
+++ b/test/options.spec.ts
@@ -21,7 +21,7 @@ test('should create two suites with different options', async ({ runInlineTest }
     'folio.config.ts': `
       global.logs = [];
       class MyEnv {
-        async beforeEach(testInfo) {
+        async beforeEach(args, testInfo) {
           return { foo: testInfo.testOptions.foo || 'foo' };
         }
       }

--- a/test/test-extend.spec.ts
+++ b/test/test-extend.spec.ts
@@ -1,0 +1,187 @@
+/**
+ * Copyright Microsoft Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { test, expect } from './config';
+
+test('test.extend should work', async ({ runInlineTest }) => {
+  const { output, passed } = await runInlineTest({
+    'folio.config.ts': `
+      global.logs = [];
+      export class MyEnv {
+        constructor(suffix) {
+          this.suffix = suffix;
+        }
+        async beforeAll() {
+          global.logs.push('beforeAll' + this.suffix);
+        }
+        async afterAll() {
+          global.logs.push('afterAll' + this.suffix);
+          if (this.suffix.includes('base'))
+            console.log(global.logs.join('\\n'));
+        }
+        async beforeEach() {
+          global.logs.push('beforeEach' + this.suffix);
+          return { foo: 'bar' };
+        }
+        async afterEach() {
+          global.logs.push('afterEach' + this.suffix);
+        }
+      }
+      export const base = folio.newTestType();
+      base.runWith(new MyEnv('-base1'));
+      base.runWith(new MyEnv('-base2'));
+    `,
+    'helper.ts': `
+      import { base, MyEnv } from './folio.config';
+      export const test1 = base.extend(new MyEnv('-e1'));
+      export const test2 = base.extend(new MyEnv('-e2'));
+    `,
+    'a.test.js': `
+      const { test1, test2 } = require('./helper');
+      test1('should work', async ({foo}) => {
+        global.logs.push('test1');
+        expect(foo).toBe('bar');
+      });
+      test2('should work', async ({foo}) => {
+        global.logs.push('test2');
+        expect(foo).toBe('bar');
+      });
+    `,
+    'b.test.js': `
+      const { test1 } = require('./helper');
+      test1('should work', async ({foo}) => {
+        global.logs.push('test3');
+        expect(foo).toBe('bar');
+      });
+    `,
+  });
+  expect(passed).toBe(6);
+  expect(output).toContain([
+    'beforeAll-base1',
+    'beforeAll-e1',
+    'beforeEach-base1',
+    'beforeEach-e1',
+    'test1',
+    'afterEach-e1',
+    'afterEach-base1',
+    'afterAll-e1',
+    'afterAll-base1',
+  ].join('\n'));
+  expect(output).toContain([
+    'beforeAll-base1',
+    'beforeAll-e2',
+    'beforeEach-base1',
+    'beforeEach-e2',
+    'test2',
+    'afterEach-e2',
+    'afterEach-base1',
+    'afterAll-e2',
+    'afterAll-base1',
+  ].join('\n'));
+  expect(output).toContain([
+    'beforeAll-base2',
+    'beforeAll-e1',
+    'beforeEach-base2',
+    'beforeEach-e1',
+    'test1',
+    'afterEach-e1',
+    'afterEach-base2',
+    'afterAll-e1',
+    'afterAll-base2',
+  ].join('\n'));
+  expect(output).toContain([
+    'beforeAll-base2',
+    'beforeAll-e2',
+    'beforeEach-base2',
+    'beforeEach-e2',
+    'test2',
+    'afterEach-e2',
+    'afterEach-base2',
+    'afterAll-e2',
+    'afterAll-base2',
+  ].join('\n'));
+  expect(output).toContain([
+    'beforeAll-base1',
+    'beforeAll-e1',
+    'beforeEach-base1',
+    'beforeEach-e1',
+    'test3',
+    'afterEach-e1',
+    'afterEach-base1',
+    'afterAll-e1',
+    'afterAll-base1',
+  ].join('\n'));
+  expect(output).toContain([
+    'beforeAll-base2',
+    'beforeAll-e1',
+    'beforeEach-base2',
+    'beforeEach-e1',
+    'test3',
+    'afterEach-e1',
+    'afterEach-base2',
+    'afterAll-e1',
+    'afterAll-base2',
+  ].join('\n'));
+});
+
+test('test.extend should work with plain object syntax', async ({ runInlineTest }) => {
+  const { output, passed } = await runInlineTest({
+    'folio.config.ts': `
+      export const test = folio.newTestType().extend({
+        async beforeEach() {
+          this.foo = 'bar';
+          return { foo: this.foo };
+        },
+        afterEach(testInfo) {
+          console.log('afterEach=' + this.foo + ';' + testInfo.title);
+        },
+      });
+      test.runWith({});
+    `,
+    'a.test.js': `
+      const { test } = require('./folio.config');
+      test('test1', async ({foo}) => {
+        expect(foo).toBe('bar');
+      });
+    `,
+  });
+  expect(passed).toBe(1);
+  expect(output).toContain('afterEach=bar;test1');
+});
+
+test('test.declare should for', async ({ runInlineTest }) => {
+  const { failed, passed, skipped } = await runInlineTest({
+    'folio.config.ts': `
+      const test = folio.newTestType();
+      export const test1 = test.declare();
+      test1.runWith({});
+      export const test2 = test.declare();
+      test2.runWith({}, { timeout: 100 });
+    `,
+    'a.test.js': `
+      const { test1, test2 } = require('./folio.config');
+      test1('test1', async ({}) => {
+        await new Promise(f => setTimeout(f, 1000));
+      });
+      test2('test2', async ({}) => {
+        await new Promise(f => setTimeout(f, 1000));
+      });
+    `,
+  });
+  expect(passed).toBe(1);
+  expect(failed).toBe(1);
+  expect(skipped).toBe(0);
+});

--- a/test/test-info.spec.ts
+++ b/test/test-info.spec.ts
@@ -34,7 +34,7 @@ test('should work via env', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'folio.config.ts': `
       class MyEnv {
-        async beforeEach(testInfo) {
+        async beforeEach(args, testInfo) {
           return { title: testInfo.title };
         }
       }

--- a/test/test-output-dir.spec.ts
+++ b/test/test-output-dir.spec.ts
@@ -50,7 +50,7 @@ test('should include runWith tag', async ({ runInlineTest }) => {
         constructor(snapshotPathSegment) {
           this._snapshotPathSegment = snapshotPathSegment;
         }
-        async beforeEach(testInfo) {
+        async beforeEach(args, testInfo) {
           testInfo.snapshotPathSegment = this._snapshotPathSegment;
           return {};
         }

--- a/test/types-2.spec.ts
+++ b/test/types-2.spec.ts
@@ -56,3 +56,59 @@ test('can return anything from hooks', async ({runTSC}) => {
   });
   expect(result.exitCode).toBe(0);
 });
+
+test('test.declare should check types', async ({runTSC}) => {
+  const result = await runTSC({
+    'folio.config.ts': `
+      export const test = folio.newTestType();
+      const x: number = '123';  // To match line numbers easier.
+      export const test1 = test.declare<{ foo: string }>();
+      export const test2 = test1.extend({ beforeEach: ({ foo }) => { return { bar: parseInt(foo) }; } });
+      test.runWith({});
+      test1.runWith({});  // error
+      test1.runWith({ beforeEach: () => { return { foo: 'foo' }; }});
+      test1.runWith({ beforeEach: () => { return { foo: 42 }; }});  // error
+      test2.runWith({});  // error
+      test2.runWith({ beforeEach: () => { return { foo: 'foo' }; }});
+      export const test3 = test1.declare<{ baz: number }>();
+      test3.runWith({ beforeEach: () => { return { foo: 'foo' }; }});  // error
+      test3.runWith({ beforeEach: ({ baz }) => { return { foo: 'foo', baz: 42 }; }});  // error
+      test3.runWith({ beforeEach: () => { return { foo: 'foo', baz: 42 }; }});
+    `,
+    'a.spec.ts': `
+      import { test, test1, test2, test3 } from './folio.config';
+      const x: number = '123';  // To match line numbers easier.
+      test('my test', async ({ foo }) => {});  // error
+      test1('my test', async ({ foo }) => {});
+      test1('my test', async ({ foo, bar }) => {});  // error
+      test2('my test', async ({ foo, bar }) => {});
+      test3('my test', async ({ foo, baz }) => {});
+      test3('my test', async ({ foo, bar }) => {});  // error
+      test2('my test', async ({ foo, baz }) => {});  // error
+    `
+  });
+  expect(result.exitCode).not.toBe(0);
+
+  expect(result.output).toContain(`folio.config.ts(5,13): error TS2322: Type 'string' is not assignable to type 'number'.`);
+  expect(result.output).not.toContain('folio.config.ts(6');
+  expect(result.output).not.toContain('folio.config.ts(7');
+  expect(result.output).not.toContain('folio.config.ts(8');
+  expect(result.output).toContain('folio.config.ts(9');
+  expect(result.output).not.toContain('folio.config.ts(10');
+  expect(result.output).toContain('folio.config.ts(11');
+  expect(result.output).toContain('folio.config.ts(12');
+  expect(result.output).not.toContain('folio.config.ts(13');
+  expect(result.output).not.toContain('folio.config.ts(14');
+  expect(result.output).toContain('folio.config.ts(15');
+  expect(result.output).toContain('folio.config.ts(16');
+  expect(result.output).not.toContain('folio.config.ts(17');
+
+  expect(result.output).toContain(`a.spec.ts(6,13): error TS2322: Type 'string' is not assignable to type 'number'.`);
+  expect(result.output).toContain('a.spec.ts(7');
+  expect(result.output).not.toContain('a.spec.ts(8');
+  expect(result.output).toContain('a.spec.ts(9');
+  expect(result.output).not.toContain('a.spec.ts(10');
+  expect(result.output).not.toContain('a.spec.ts(11');
+  expect(result.output).toContain('a.spec.ts(12');
+  expect(result.output).toContain('a.spec.ts(13');
+});


### PR DESCRIPTION
These two are used for adding an environment to an existing test type.
An example of adding `newValue` to test arguments:

```ts
import { test as base } from './my.config';

const test = base.extend({
  beforeEach(args, testInfo) {
    const newValue = initValue(args);
    return { newValue };
  }
});

test('my test', ({ newValue }) => {
});
```

Under the hood:
- test types now form a hierarchy;
- `runWith` call affects all test types from the subtree;
- worker initializes a list of environments instead of a single one.