### PR TITLE
feat: remove newTestType and merge

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -15,8 +15,8 @@
  * limitations under the License.
  */
 
-import type { Env, TestType } from './types';
-import { newTestTypeImpl, mergeEnvsImpl } from './spec';
+import type { TestType } from './types';
+import { newTestTypeImpl } from './spec';
 import DotReporter from './reporters/dot';
 import JSONReporter from './reporters/json';
 import JUnitReporter from './reporters/junit';
@@ -26,18 +26,7 @@ import ListReporter from './reporters/list';
 export * from './types';
 export { expect } from './expect';
 export { setConfig, setReporters, globalSetup, globalTeardown } from './spec';
-
-export function newTestType<TestArgs = {}, TestOptions = {}>(): TestType<TestArgs, TestOptions, TestArgs> {
-  return newTestTypeImpl([]);
-}
-
-export function merge<TestArgs>(env: Env<TestArgs>): Env<TestArgs>;
-export function merge<TestArgs1, TestArgs2>(env1: Env<TestArgs1>, env2: Env<TestArgs2>): Env<TestArgs1 & TestArgs2>;
-export function merge<TestArgs1, TestArgs2, TestArgs3>(env1: Env<TestArgs1>, env2: Env<TestArgs2>, env3: Env<TestArgs3>): Env<TestArgs1 & TestArgs2 & TestArgs3>;
-export function merge(...envs: any): Env<any> {
-  return mergeEnvsImpl(envs);
-}
-
+export const test: TestType<{}, {}, {}> = newTestTypeImpl([]);
 export const reporters = {
   dot: DotReporter,
   json: JSONReporter,

--- a/src/types.ts
+++ b/src/types.ts
@@ -115,12 +115,18 @@ export interface TestType<TestArgs, TestOptions, DeclaredTestArgs> extends TestF
 
   expect: Expect;
 
+  extend(): TestType<TestArgs, TestOptions, DeclaredTestArgs>;
   extend<T>(env: Env<T, TestArgs>): TestType<TestArgs & T, TestOptions, DeclaredTestArgs>;
   declare<T>(): TestType<TestArgs & T, TestOptions, DeclaredTestArgs & T>;
+  declareTestOptions<O>(): TestType<TestArgs, TestOptions & O, DeclaredTestArgs>;
 
-  runWith(env: OptionalEnv<DeclaredTestArgs>): void;
-  runWith(env: OptionalEnv<DeclaredTestArgs>, config: RunWithConfig): void;
+  runWith(config: RunWithConfig, env: OptionalEnv<DeclaredTestArgs>): void;
+  runWith<Args1>(config: RunWithConfig, env1: Env<Args1>, env2: Env<Diff<DeclaredTestArgs, Args1>>): void;
+  runWith<Args1, Args2>(config: RunWithConfig, env1: Env<Args1>, env2: Env<Args2>, env3: Env<Diff<DeclaredTestArgs, Args1 & Args2>>): void;
+  runWith<Args1, Args2, Args3>(config: RunWithConfig, env1: Env<Args1>, env2: Env<Args2>, env3: Env<Args3>, env4: Env<Diff<DeclaredTestArgs, Args1 & Args2 & Args3>>): void;
 }
+
+type Diff<A, B> = A extends object ? (B extends object ? Omit<A, keyof B> : never) : never;
 
 export type RunWithConfig = SharedConfig & {
   tag?: string | string[];

--- a/test/access-data.spec.ts
+++ b/test/access-data.spec.ts
@@ -19,14 +19,13 @@ import { test, expect } from './config';
 test('should access error in env', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'folio.config.ts': `
-      const { newTestType } = folio;
       class MyEnv {
         async afterEach(testInfo) {
           console.log('ERROR[[[' + JSON.stringify(testInfo.error, undefined, 2) + ']]]');
         }
       }
-      export const test = newTestType();
-      test.runWith(new MyEnv());
+      export const test = folio.test;
+      test.runWith({}, new MyEnv());
     `,
     'test-error-visible-in-env.spec.ts': `
       import { test } from './folio.config';
@@ -45,14 +44,13 @@ test('should access error in env', async ({ runInlineTest }) => {
 test('should access data in env', async ({ runInlineTest }) => {
   const { exitCode, report } = await runInlineTest({
     'folio.config.ts': `
-      const { newTestType } = folio;
       class MyEnv {
         async afterEach(testInfo) {
           testInfo.data['myname'] = 'myvalue';
         }
       }
-      export const test = newTestType();
-      test.runWith(new MyEnv());
+      export const test = folio.test;
+      test.runWith({}, new MyEnv());
     `,
     'test-data-visible-in-env.spec.ts': `
       import { test } from './folio.config';
@@ -74,9 +72,9 @@ test('should access data in env', async ({ runInlineTest }) => {
 test('should report tags in result', async ({ runInlineTest }) => {
   const { exitCode, report } = await runInlineTest({
     'folio.config.ts': `
-      export const test = folio.newTestType();
-      test.runWith({}, { tag: ['foo', 'bar'] });
-      test.runWith(undefined, { tag: 'some tag' });
+      export const test = folio.test;
+      test.runWith({ tag: ['foo', 'bar'] }, {});
+      test.runWith({ tag: 'some tag' }, undefined);
     `,
     'test-data-visible-in-env.spec.ts': `
       import { test } from './folio.config';

--- a/test/config.spec.ts
+++ b/test/config.spec.ts
@@ -21,8 +21,8 @@ test('should be able to redefine config', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'folio.config.ts': `
       folio.setConfig({ timeout: 12345 });
-      export const test = folio.newTestType();
-      test.runWith();
+      export const test = folio.test;
+      test.runWith({});
     `,
     'a.test.ts': `
       import { test } from './folio.config';
@@ -43,8 +43,8 @@ test('should read config from --config', async ({ runInlineTest }) => {
       folio.setConfig({
         testDir: path.join(__dirname, 'dir'),
       });
-      export const test = folio.newTestType();
-      test.runWith();
+      export const test = folio.test;
+      test.runWith({});
     `,
     'a.test.ts': `
       import { test } from './my.config';
@@ -72,8 +72,8 @@ test('should be able to setReporters', async ({ runInlineTest }, testInfo) => {
         new folio.reporters.json({ outputFile: ${JSON.stringify(reportFile)}}),
         new folio.reporters.list(),
       ]);
-      export const test = folio.newTestType();
-      test.runWith();
+      export const test = folio.test;
+      test.runWith({});
     `,
     'a.test.ts': `
       import { test } from './folio.config';

--- a/test/config.ts
+++ b/test/config.ts
@@ -55,8 +55,8 @@ async function writeFiles(testInfo: folio.TestInfo, files: Files) {
     files = {
       ...files,
       'folio.config.ts': `
-        export const test = folio.newTestType();
-        test.runWith();
+        export const test = folio.test;
+        test.runWith({});
       `,
     };
   }

--- a/test/env-errors.spec.ts
+++ b/test/env-errors.spec.ts
@@ -24,8 +24,8 @@ test('should handle env afterEach timeout', async ({ runInlineTest }) => {
           await new Promise(f => setTimeout(f, 100000));
         }
       }
-      export const test = folio.newTestType();
-      test.runWith(new MyEnv());
+      export const test = folio.test;
+      test.runWith({}, new MyEnv());
     `,
     'a.spec.ts': `
       import { test } from './folio.config';
@@ -51,8 +51,8 @@ test('should handle env afterAll timeout', async ({ runInlineTest }) => {
           await new Promise(f => setTimeout(f, 100000));
         }
       }
-      export const test = folio.newTestType();
-      test.runWith(new MyEnv());
+      export const test = folio.test;
+      test.runWith({}, new MyEnv());
     `,
     'a.spec.ts': `
       import { test } from './folio.config';
@@ -72,8 +72,8 @@ test('should handle env beforeEach error', async ({ runInlineTest }) => {
           throw new Error('Worker failed');
         }
       }
-      export const test = folio.newTestType();
-      test.runWith(new MyEnv());
+      export const test = folio.test;
+      test.runWith({}, new MyEnv());
     `,
     'a.spec.ts': `
       import { test } from './folio.config';
@@ -94,8 +94,8 @@ test('should handle env afterAll error', async ({ runInlineTest }) => {
           throw new Error('Worker failed');
         }
       }
-      export const test = folio.newTestType();
-      test.runWith(new MyEnv());
+      export const test = folio.test;
+      test.runWith({}, new MyEnv());
     `,
     'a.spec.ts': `
       import { test } from './folio.config';
@@ -111,7 +111,7 @@ test('should handle env afterAll error', async ({ runInlineTest }) => {
 test('should throw when test() is called in config file', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'folio.config.ts': `
-      export const test = folio.newTestType();
+      export const test = folio.test;
       test('hey', () => {});
     `,
     'a.test.ts': `
@@ -136,8 +136,8 @@ test('should run afterAll from mulitple envs when one throws', async ({ runInlin
           console.log('env2-afterAll');
         }
       }
-      export const test = folio.newTestType();
-      test.runWith(folio.merge(new MyEnv1(), new MyEnv2()));
+      export const test = folio.test;
+      test.runWith({}, new MyEnv1(), new MyEnv2());
     `,
     'a.test.ts': `
       import { test } from './folio.config';
@@ -152,7 +152,7 @@ test('should run afterAll from mulitple envs when one throws', async ({ runInlin
 test('can only call runWith in config file', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'folio.config.ts': `
-      export const test = folio.newTestType();
+      export const test = folio.test;
       test.runWith({});
     `,
     'a.test.ts': `

--- a/test/env.spec.ts
+++ b/test/env.spec.ts
@@ -36,8 +36,8 @@ test('env should work', async ({ runInlineTest }) => {
           global.logs.push('afterEach');
         }
       }
-      export const test = folio.newTestType();
-      test.runWith(new MyEnv());
+      export const test = folio.test;
+      test.runWith({}, new MyEnv());
     `,
     'a.test.js': `
       const { test } = require('./folio.config');
@@ -77,11 +77,11 @@ const multipleEnvs = {
         global.logs.push('afterEach' + this.suffix);
       }
     }
-    exports.fooTest = folio.newTestType();
-    exports.barTest = folio.newTestType();
-    exports.fooTest.runWith(new MyEnv('-env1'), { tag: 'suite1' });
-    exports.fooTest.runWith(new MyEnv('-env2'), { tag: 'suite2' });
-    exports.barTest.runWith(new MyEnv('-env3'), { tag: 'suite3' });
+    exports.fooTest = folio.test.declare();
+    exports.barTest = folio.test.declare();
+    exports.fooTest.runWith({ tag: 'suite1' }, new MyEnv('-env1'));
+    exports.fooTest.runWith({ tag: 'suite2' }, new MyEnv('-env2'));
+    exports.barTest.runWith({ tag: 'suite3' }, new MyEnv('-env3'));
   `,
   'a.test.js': `
     const {fooTest, barTest} = require('./folio.config');
@@ -130,8 +130,8 @@ test('should teardown env after timeout', async ({ runInlineTest }, testInfo) =>
           require('fs').appendFileSync(process.env.TEST_FILE, 'afterEach\\n', 'utf8');
         }
       }
-      export const test = folio.newTestType();
-      test.runWith(new MyEnv());
+      export const test = folio.test;
+      test.runWith({}, new MyEnv());
     `,
     'a.spec.ts': `
       import { test } from './folio.config';
@@ -159,8 +159,8 @@ test('should initialize env once across files', async ({ runInlineTest }) => {
           console.log(global.logs.join('\\n'));
         }
       }
-      exports.test = folio.newTestType();
-      exports.test.runWith(new MyEnv());
+      exports.test = folio.test;
+      exports.test.runWith({}, new MyEnv());
     `,
     'a.test.js': `
       const {test} = require('./folio.config');
@@ -193,8 +193,8 @@ test('multiple envs for a single test type should work', async ({ runInlineTest 
           return { env2: testInfo.title + '-env2' };
         }
       }
-      export const test = folio.newTestType();
-      test.runWith(folio.merge(new Env1(), new Env2()));
+      export const test = folio.test;
+      test.runWith({}, new Env1(), new Env2());
     `,
     'a.test.js': `
       const { test } = require('./folio.config');
@@ -223,8 +223,8 @@ test('should run sync env methods and hooks', async ({ runInlineTest }) => {
         afterAll() {
         }
       }
-      export const test = folio.newTestType();
-      test.runWith(new Env());
+      export const test = folio.test;
+      test.runWith({}, new Env());
     `,
     'a.test.js': `
       const { test } = require('./folio.config');

--- a/test/global-setup.spec.ts
+++ b/test/global-setup.spec.ts
@@ -32,8 +32,8 @@ test('globalSetup and globalTeardown should work', async ({ runInlineTest }) => 
       folio.globalSetup(async () => {
         process.env.BAR = 'baz';
       });
-      export const test = folio.newTestType();
-      test.runWith();
+      export const test = folio.test;
+      test.runWith({});
     `,
     'a.test.js': `
       const { test } = require('./folio.config');
@@ -59,8 +59,8 @@ test('globalTeardown runs after failures', async ({ runInlineTest }) => {
       folio.globalTeardown(() => {
         console.log('teardown=' + value);
       });
-      export const test = folio.newTestType();
-      test.runWith();
+      export const test = folio.test;
+      test.runWith({}, undefined);
     `,
     'a.test.js': `
       const { test } = require('./folio.config');
@@ -83,8 +83,8 @@ test('globalTeardown does not run when globalSetup times out', async ({ runInlin
       folio.globalTeardown(() => {
         console.log('teardown=');
       });
-      export const test = folio.newTestType();
-      test.runWith();
+      export const test = folio.test;
+      test.runWith({});
       folio.setConfig({ globalTimeout: 1000 });
     `,
     'a.test.js': `
@@ -107,8 +107,8 @@ test('globalSetup should be run before requiring tests', async ({ runInlineTest 
       folio.globalSetup(async () => {
         process.env.FOO = JSON.stringify({ foo: 'bar' });
       });
-      export const test = folio.newTestType();
-      test.runWith();
+      export const test = folio.test;
+      test.runWith({});
     `,
     'a.test.js': `
       const { test } = require('./folio.config');

--- a/test/hooks.spec.ts
+++ b/test/hooks.spec.ts
@@ -35,8 +35,8 @@ test('hooks should work with env', async ({ runInlineTest }) => {
           global.logs.push('-t');
         }
       }
-      export const test = folio.newTestType();
-      test.runWith(new MyEnv());
+      export const test = folio.test;
+      test.runWith({}, new MyEnv());
     `,
     'a.test.js': `
       const { test } = require('./folio.config');
@@ -92,8 +92,8 @@ test('afterEach failure should not prevent other hooks and env teardown', async 
           console.log('-t');
         }
       }
-      export const test = folio.newTestType();
-      test.runWith(new MyEnv());
+      export const test = folio.test;
+      test.runWith({}, new MyEnv());
     `,
     'a.test.js': `
       const { test } = require('./folio.config');

--- a/test/junit-reporter.spec.ts
+++ b/test/junit-reporter.spec.ts
@@ -110,8 +110,8 @@ test('render stdout', async ({ runInlineTest }) => {
 test('render stdout without ansi escapes', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'folio.config.ts': `
-      export const test = folio.newTestType();
-      test.runWith();
+      export const test = folio.test;
+      test.runWith({});
       folio.setReporters([new folio.reporters.junit({ stripANSIControlSequences: true })]);
     `,
     'a.test.ts': `

--- a/test/list-reporter.spec.ts
+++ b/test/list-reporter.spec.ts
@@ -19,9 +19,9 @@ import { test, expect, stripAscii } from './config';
 test('render each test with tags', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'folio.config.ts': `
-      export const test = folio.newTestType();
-      test.runWith({ beforeAll: async () => {} }, { tag: 'foo' });
-      test.runWith({ beforeAll: async () => {} }, { tag: 'bar' });
+      export const test = folio.test;
+      test.runWith({ tag: 'foo' });
+      test.runWith({ tag: 'bar' });
     `,
     'a.test.ts': `
       import { test } from './folio.config';

--- a/test/options.spec.ts
+++ b/test/options.spec.ts
@@ -25,8 +25,8 @@ test('should create two suites with different options', async ({ runInlineTest }
           return { foo: testInfo.testOptions.foo || 'foo' };
         }
       }
-      export const test = folio.newTestType();
-      test.runWith(new MyEnv());
+      export const test = folio.test;
+      test.runWith({}, new MyEnv());
     `,
     'a.test.ts': `
       import { test } from './folio.config';

--- a/test/output-path.spec.ts
+++ b/test/output-path.spec.ts
@@ -49,8 +49,8 @@ test('should include retry token', async ({runInlineTest}) => {
 test('should include tag', async ({runInlineTest}) => {
   const result = await runInlineTest({
     'folio.config.ts': `
-      export const test = folio.newTestType();
-      test.runWith({}, { tag: 'my-title' });
+      export const test = folio.test;
+      test.runWith({ tag: 'my-title' });
     `,
     'a.spec.js': `
       const { test } = require('./folio.config');
@@ -78,9 +78,9 @@ test('should remove output paths', async ({runInlineTest}, testInfo) => {
 
   const result = await runInlineTest({
     'folio.config.js': `
-      exports.test = folio.newTestType();
-      exports.test.runWith(undefined, { outputDir: ${JSON.stringify(paths[0])} });
-      exports.test.runWith(void 0, { outputDir: ${JSON.stringify(paths[2])} });
+      exports.test = folio.test;
+      exports.test.runWith({ outputDir: ${JSON.stringify(paths[0])} }, undefined);
+      exports.test.runWith({ outputDir: ${JSON.stringify(paths[2])} }, void 0);
     `,
     'a.test.js': `
       const { test } = require('./folio.config');

--- a/test/override-timeout.spec.ts
+++ b/test/override-timeout.spec.ts
@@ -20,8 +20,8 @@ test('should consider dynamically set value', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'folio.config.js': `
       folio.setConfig({ timeout: 100 });
-      exports.test = folio.newTestType();
-      exports.test.runWith();
+      exports.test = folio.test;
+      exports.test.runWith({});
     `,
     'a.test.js': `
       const { test } = require('./folio.config');
@@ -38,8 +38,8 @@ test('should allow different timeouts', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'folio.config.js': `
       folio.setConfig({ timeout: 100 });
-      exports.test = folio.newTestType();
-      exports.test.runWith({}, { timeout: 200 });
+      exports.test = folio.test;
+      exports.test.runWith({ timeout: 200 });
       exports.test.runWith({});
     `,
     'a.test.js': `
@@ -59,8 +59,8 @@ test('should prioritize value set via command line', async ({ runInlineTest }) =
   const result = await runInlineTest({
     'folio.config.js': `
       folio.setConfig({ timeout: 100 });
-      exports.test = folio.newTestType();
-      exports.test.runWith();
+      exports.test = folio.test;
+      exports.test.runWith({});
     `,
     'a.test.js': `
       const { test } = require('./folio.config');

--- a/test/repeat-each.spec.ts
+++ b/test/repeat-each.spec.ts
@@ -36,9 +36,9 @@ test('should repeat from command line', async ({runInlineTest}) => {
 test('should repeat based on config', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'folio.config.js': `
-      exports.test = folio.newTestType();
-      exports.test.runWith(undefined, { tag: 'no-repeats' });
-      exports.test.runWith({}, { repeatEach: 2, tag: 'two-repeats' });
+      exports.test = folio.test;
+      exports.test.runWith({ tag: 'no-repeats' });
+      exports.test.runWith({ repeatEach: 2, tag: 'two-repeats' });
     `,
     'a.test.js': `
       const { test } = require('./folio.config');

--- a/test/retry.spec.ts
+++ b/test/retry.spec.ts
@@ -40,9 +40,9 @@ test('should retry based on config', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'folio.config.js': `
       folio.setConfig({ retries: 1 });
-      exports.test = folio.newTestType();
-      exports.test.runWith({}, { retries: 0, tag: 'no-retries' });
-      exports.test.runWith({}, { retries: 2, tag: 'two-retries' });
+      exports.test = folio.test;
+      exports.test.runWith({ retries: 0, tag: 'no-retries' });
+      exports.test.runWith({ retries: 2, tag: 'two-retries' });
     `,
     'a.test.js': `
       const { test } = require('./folio.config');
@@ -164,8 +164,8 @@ test('should retry env.beforeAll failure', async ({ runInlineTest }) => {
           throw new Error('env.beforeAll is bugged!');
         }
       }
-      export const test = folio.newTestType();
-      test.runWith(new MyEnv());
+      export const test = folio.test;
+      test.runWith({}, new MyEnv());
     `,
     'a.spec.ts': `
       import { test } from './folio.config';

--- a/test/stdio.spec.ts
+++ b/test/stdio.spec.ts
@@ -48,8 +48,8 @@ test('should get stdio from env afterAll', async ({runInlineTest}) => {
           console.log('\\n%% worker teardown');
         }
       }
-      export const test = folio.newTestType();
-      test.runWith(new MyEnv());
+      export const test = folio.test;
+      test.runWith({}, new MyEnv());
     `,
     'a.spec.js': `
       const { test } = require('./folio.config');

--- a/test/test-extend.spec.ts
+++ b/test/test-extend.spec.ts
@@ -40,9 +40,9 @@ test('test.extend should work', async ({ runInlineTest }) => {
           global.logs.push('afterEach' + this.suffix);
         }
       }
-      export const base = folio.newTestType();
-      base.runWith(new MyEnv('-base1'));
-      base.runWith(new MyEnv('-base2'));
+      export const base = folio.test;
+      base.runWith({}, new MyEnv('-base1'));
+      base.runWith({}, new MyEnv('-base2'));
     `,
     'helper.ts': `
       import { base, MyEnv } from './folio.config';
@@ -140,7 +140,7 @@ test('test.extend should work', async ({ runInlineTest }) => {
 test('test.extend should work with plain object syntax', async ({ runInlineTest }) => {
   const { output, passed } = await runInlineTest({
     'folio.config.ts': `
-      export const test = folio.newTestType().extend({
+      export const test = folio.test.extend({
         async beforeEach() {
           this.foo = 'bar';
           return { foo: this.foo };
@@ -165,11 +165,10 @@ test('test.extend should work with plain object syntax', async ({ runInlineTest 
 test('test.declare should for', async ({ runInlineTest }) => {
   const { failed, passed, skipped } = await runInlineTest({
     'folio.config.ts': `
-      const test = folio.newTestType();
-      export const test1 = test.declare();
+      export const test1 = folio.test.declare();
       test1.runWith({});
-      export const test2 = test.declare();
-      test2.runWith({}, { timeout: 100 });
+      export const test2 = folio.test.declare();
+      test2.runWith({ timeout: 100 });
     `,
     'a.test.js': `
       const { test1, test2 } = require('./folio.config');

--- a/test/test-ignore.spec.ts
+++ b/test/test-ignore.spec.ts
@@ -94,8 +94,8 @@ test('should use an array for testMatch', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'folio.config.ts': `
       folio.setConfig({ testMatch: ['b.test.ts', /^a.*TS$/i] });
-      export const test = folio.newTestType();
-      test.runWith();
+      export const test = folio.test;
+      test.runWith({});
     `,
     'a.test.ts': `
       import { test } from './folio.config';

--- a/test/test-info.spec.ts
+++ b/test/test-info.spec.ts
@@ -38,8 +38,8 @@ test('should work via env', async ({ runInlineTest }) => {
           return { title: testInfo.title };
         }
       }
-      export const test = folio.newTestType();
-      test.runWith(new MyEnv());
+      export const test = folio.test;
+      test.runWith({}, new MyEnv());
     `,
     'a.test.js': `
       const { test } = require('./folio.config');

--- a/test/test-output-dir.spec.ts
+++ b/test/test-output-dir.spec.ts
@@ -55,12 +55,12 @@ test('should include runWith tag', async ({ runInlineTest }) => {
           return {};
         }
       }
-      export const test = folio.newTestType();
-      export const test2 = folio.newTestType();
-      test.runWith(new Env('snapshots1'), { tag: 'foo' });
-      test.runWith(new Env('snapshots2'), { tag: 'foo' });
-      test2.runWith(new Env('snapshots1'), { tag: 'foo' });
-      test2.runWith(new Env('snapshots1'), { tag: ['a', 'b'] });
+      export const test = folio.test.extend();
+      export const test2 = folio.test.extend();
+      test.runWith({ tag: 'foo' }, new Env('snapshots1'));
+      test.runWith({ tag: 'foo' }, new Env('snapshots2'));
+      test2.runWith({ tag: 'foo' }, new Env('snapshots1'));
+      test2.runWith({ tag: ['a', 'b'] }, new Env('snapshots1'));
     `,
     'my-test.spec.js': `
       const { test, test2 } = require('./folio.config');

--- a/test/timeout.spec.ts
+++ b/test/timeout.spec.ts
@@ -24,8 +24,8 @@ test('should run env afterEach on timeout', async ({ runInlineTest }) => {
           console.log('STATUS:' + testInfo.status);
         }
       }
-      export const test = folio.newTestType();
-      test.runWith(new MyEnv());
+      export const test = folio.test;
+      test.runWith({}, new MyEnv());
     `,
     'c.spec.ts': `
       import { test } from './folio.config';

--- a/test/types-2.spec.ts
+++ b/test/types-2.spec.ts
@@ -60,20 +60,20 @@ test('can return anything from hooks', async ({runTSC}) => {
 test('test.declare should check types', async ({runTSC}) => {
   const result = await runTSC({
     'folio.config.ts': `
-      export const test = folio.newTestType();
+      export const test = folio.test;
       const x: number = '123';  // To match line numbers easier.
       export const test1 = test.declare<{ foo: string }>();
       export const test2 = test1.extend({ beforeEach: ({ foo }) => { return { bar: parseInt(foo) }; } });
       test.runWith({});
       test1.runWith({});  // error
-      test1.runWith({ beforeEach: () => { return { foo: 'foo' }; }});
-      test1.runWith({ beforeEach: () => { return { foo: 42 }; }});  // error
-      test2.runWith({});  // error
-      test2.runWith({ beforeEach: () => { return { foo: 'foo' }; }});
+      test1.runWith({}, { beforeEach: () => { return { foo: 'foo' }; }});
+      test1.runWith({}, { beforeEach: () => { return { foo: 42 }; }});  // error
+      test2.runWith({}, {});  // error
+      test2.runWith({}, { beforeEach: () => { return { foo: 'foo' }; }});
       export const test3 = test1.declare<{ baz: number }>();
-      test3.runWith({ beforeEach: () => { return { foo: 'foo' }; }});  // error
-      test3.runWith({ beforeEach: ({ baz }) => { return { foo: 'foo', baz: 42 }; }});  // error
-      test3.runWith({ beforeEach: () => { return { foo: 'foo', baz: 42 }; }});
+      test3.runWith({}, { beforeEach: () => { return { foo: 'foo' }; }});  // error
+      test3.runWith({}, { beforeEach: ({ baz }) => { return { foo: 'foo', baz: 42 }; }});  // error
+      test3.runWith({}, { beforeEach: () => { return { foo: 'foo', baz: 42 }; }});
     `,
     'a.spec.ts': `
       import { test, test1, test2, test3 } from './folio.config';

--- a/test/types.spec.ts
+++ b/test/types.spec.ts
@@ -39,13 +39,14 @@ test('runWith should check types', async ({runTSC}) => {
           return { b: 42 };
         }
       }
-      export const test = folio.newTestType<{ a: string, b: number }>();
+      export const test = folio.test.declare<{ a: string, b: number }>();
       const x: number = '123';  // To match line numbers easier.
+      test.runWith({}, new Env1());  // error
+      test.runWith({}, new Env1(), new Env2());
+      test.runWith({}, new Env1(), new Env1(), { beforeEach: async () => { return {}; } });  // error
       test.runWith(new Env1());  // error
-      test.runWith(folio.merge(new Env1(), new Env2()));
-      test.runWith(new Env1(), {});  // error
-      test.runWith(new Env1(), { timeout: 100 });  // error
-      test.runWith(folio.merge(new Env1(), new Env2()), { timeout: 100, tag: ['tag1', 'tag2'] });
+      test.runWith({ timeout: 100 }, new Env1());  // error
+      test.runWith({ timeout: 100, tag: ['tag1', 'tag2'] }, new Env2(), new Env1());
       test.runWith({ timeout: 100 });  // error
       test.runWith('alias');  // error
       test.runWith({});  // error
@@ -62,25 +63,26 @@ test('runWith should check types', async ({runTSC}) => {
   expect(result.output).not.toContain('folio.config.ts(17');
   expect(result.output).toContain('folio.config.ts(18');
   expect(result.output).toContain('folio.config.ts(19');
-  expect(result.output).not.toContain('folio.config.ts(20');
-  expect(result.output).toContain('folio.config.ts(21');
+  expect(result.output).toContain('folio.config.ts(20');
+  expect(result.output).not.toContain('folio.config.ts(21');
   expect(result.output).toContain('folio.config.ts(22');
   expect(result.output).toContain('folio.config.ts(23');
+  expect(result.output).toContain('folio.config.ts(24');
 });
 
 test('runWith should allow void env', async ({runTSC}) => {
   const result = await runTSC({
     'folio.config.ts': `
-      export const test = folio.newTestType();
+      export const test = folio.test;
       const x: number = '123';  // To match line numbers easier.
-      test.runWith();
-      test.runWith('alias');  // error
-      test.runWith('foo', 'bar');  // error
-      test.runWith({ timeout: 100 });  // error
-      test.runWith({}, { timeout: 100 });
-      test.runWith(undefined, { timeout: 100 });
-      test.runWith({ beforeEach: () => {} }, { timeout: 100 });
-      test.runWith({ beforeEach: () => { return 42; } }, { timeout: 100 });  // error
+      test.runWith({});
+      test.runWith({}, 'alias');  // error
+      test.runWith({}, 'foo', 'bar');  // error
+      test.runWith({}, { timeout: 100 });  // error
+      test.runWith({ timeout: 100 }, {});
+      test.runWith({ timeout: 100 }, undefined);
+      test.runWith({ timeout: 100 }, { beforeEach: () => {} });
+      test.runWith({ timeout: 100 }, { beforeEach: () => { return 42; } });  // error
     `,
     'a.spec.ts': `
       import { test } from './folio.config';
@@ -103,7 +105,7 @@ test('runWith should allow void env', async ({runTSC}) => {
 test('test.extend should check types', async ({runTSC}) => {
   const result = await runTSC({
     'folio.config.ts': `
-      export const test = folio.newTestType<{ foo: string }>();
+      export const test = folio.test.declare<{ foo: string }>();
       class FooEnv {
         beforeEach() {
           return { foo: '17' };
@@ -111,14 +113,14 @@ test('test.extend should check types', async ({runTSC}) => {
       }
       const x: number = '123';  // To match line numbers easier.
       export const test1 = test.extend({ beforeEach: ({ foo }) => { return { bar: parseInt(foo) + 42 }; } });
-      test.runWith({});  // error
-      test1.runWith({});  // error
-      test.runWith(new FooEnv());
-      test1.runWith({});  // error
-      test1.runWith(new FooEnv());
+      test.runWith({}, {});  // error
+      test1.runWith({}, {});  // error
+      test.runWith({}, new FooEnv());
+      test1.runWith({}, {});  // error
+      test1.runWith({}, new FooEnv());
       export const test2 = test1.extend({ beforeEach: ({ bar }) => { return { baz: bar - 5 }; } });
-      test2.runWith({});  // error
-      test2.runWith(new FooEnv());
+      test2.runWith({}, {});  // error
+      test2.runWith({}, new FooEnv());
       export const test3 = test.extend({ beforeEach: ({ bar }) => { return { baz: bar - 5 }; } });  // error
     `,
     'a.spec.ts': `

--- a/test/worker-index.spec.ts
+++ b/test/worker-index.spec.ts
@@ -69,10 +69,10 @@ test('should reuse worker for multiple tests', async ({ runInlineTest }) => {
 test('should not reuse worker for different suites', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'folio.config.ts': `
-      export const test = folio.newTestType();
-      test.runWith();
-      test.runWith();
-      test.runWith();
+      export const test = folio.test;
+      test.runWith({});
+      test.runWith({});
+      test.runWith({});
     `,
     'a.test.js': `
       const { test } = require('./folio.config');


### PR DESCRIPTION
- Exports a root `folio.test` test type.
- Instead of `folio.newTestType<T>()`, we can do `folio.test.declare<T>()`.
- Instead of `test.runWith(folio.merge(env1, env2), config)`, we can do `test.runWith(config, env1, env2)`.
