### PR TITLE
test: added testing for types on bots

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
       run: npm run build
     - name: lint
       run: npm run lint
-  build:
+  test:
     timeout-minutes: 30
     strategy:
       fail-fast: false
@@ -43,3 +43,19 @@ jobs:
       run: npm run build
     - name: test
       run: npm run test
+  test-types:
+    timeout-minutes: 30
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v1
+      with:
+        node-version: '10.x'
+    - name: preinstall
+      run: npm run roll-dogfood
+    - name: install
+      run: npm i
+    - name: build
+      run: npm run build
+    - name: test
+      run: npm run test-types

--- a/README.md
+++ b/README.md
@@ -418,6 +418,8 @@ export const smokeTest = folio.newTestType<{ value: string }>();
 // - Some special tests that require different arguments.
 export const fooTest = folio.newTestType<{ foo: number }>();
 
+export const expect = folio.expect;
+
 // Environment with some test value.
 class MockedEnv {
   async beforeEach() {
@@ -459,7 +461,7 @@ We can now use our test types to write tests:
 ```ts
 // some.spec.ts
 
-import { test, slowTest, smokeTest, fooTest } from './folio.config';
+import { test, expect, slowTest, smokeTest, fooTest } from './folio.config';
 
 test('just a test', async ({ value }) => {
   // This test will be retried.

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "build": "tsc --build tsconfig.json",
     "watch": "tsc --build tsconfig.json --watch",
     "test": "folio --config=test/config.ts",
+    "test-types": "tsc -p test-types/tsconfig.json",
     "prepare": "npm run build",
     "roll-dogfood": "cd dogfood && npm install",
     "prepublishOnly": "rm tsconfig.tsbuildinfo && rm -rf out && npm run build"

--- a/test-types/example-writing-a-configuration-file/folio.config.ts
+++ b/test-types/example-writing-a-configuration-file/folio.config.ts
@@ -1,0 +1,70 @@
+/**
+ * Copyright Microsoft Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as fs from 'fs';
+
+import * as folio from '../../out';
+
+// 20 seconds timeout, 3 retries by default.
+folio.setConfig({ testDir: __dirname, timeout: 20000, retries: 3 });
+
+// Define as many test types as you'd like:
+// - Generic test that only needs a string value.
+export const test = folio.newTestType<{ value: string }>();
+// - Slow test for extra-large data sets.
+export const slowTest = folio.newTestType<{ value: string }>();
+// - Smoke tests should not be flaky.
+export const smokeTest = folio.newTestType<{ value: string }>();
+// - Some special tests that require different arguments.
+export const fooTest = folio.newTestType<{ foo: number }>();
+
+export const expect = folio.expect;
+
+// Environment with some test value.
+class MockedEnv {
+  async beforeEach() {
+    return { value: 'some test value' };
+  }
+}
+
+// Another environment that reads from file.
+class FileEnv {
+  value: string;
+  constructor() {
+    this.value = fs.readFileSync('data.txt', 'utf8');
+  }
+  async beforeEach() {
+    return { value: this.value };
+  }
+}
+
+// This environment provides foo.
+class FooEnv {
+  async beforeEach() {
+    return { foo: 42 };
+  }
+}
+
+// Now we can run tests in different configurations:
+// - Generics tests with two different environments.
+test.runWith(new MockedEnv());
+test.runWith(new FileEnv());
+// - Increased timeout for slow tests.
+slowTest.runWith(new MockedEnv(), { timeout: 100000 });
+// - Smoke tests without retries.
+//   Adding a tag allows to run just the smoke tests with `npx folio --tag=smoke`.
+smokeTest.runWith(new MockedEnv(), { retries: 0, tag: 'smoke' });
+// - Special foo tests need a different environment.
+fooTest.runWith(new FooEnv());

--- a/test-types/example-writing-a-configuration-file/test.ts
+++ b/test-types/example-writing-a-configuration-file/test.ts
@@ -1,0 +1,20 @@
+/**
+ * Copyright Microsoft Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { test } from './folio.config';
+
+test('math works?', () => {
+  test.expect(1 + 1).toBe(42);
+});

--- a/test-types/tsconfig.json
+++ b/test-types/tsconfig.json
@@ -1,0 +1,12 @@
+{
+    "compilerOptions": {
+      "strict": true,
+      "target": "es2015",
+      "noEmit": true,
+      "moduleResolution": "node",
+      "allowSyntheticDefaultImports": true
+    },
+    "include": [
+      "./**/*"
+    ]
+}


### PR DESCRIPTION
Preparation for the expect PR (#221), so we ensure it works with the discussed scenarios. The testing is similar to the one we do in PW directly.

Didn't copy / verify all the examples from the README yet, because maybe you want to change something.