### PR TITLE
feat: rework api

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A customizable test framework to build your own test frameworks. Foundation for the [Playwright test runner](https://github.com/microsoft/playwright-test).
 
+Folio is **available in preview** and is under active development. Breaking changes could happen. We welcome your feedback to shape this towards 1.0.
+
 ## Docs
 
 - [Isolation and flexibility](#isolation-and-flexibility)
@@ -81,10 +83,10 @@ import * as folio from 'folio';
 // Configure Folio to look for tests in this directory, and give each test 20 seconds.
 folio.setConfig({ testDir: __dirname, timeout: 20000 });
 
-// Create a new test type. For the easiest setup, you need just one.
-export const test = folio.newTestType();
+// Create a test type. For the easiest setup, you can use a default one.
+export const test = folio.test;
 
-// Run tests of this type, giving them two retries.
+// Run tests with two retries.
 test.runWith({ tag: 'basic', retries: 2 });
 ```
 
@@ -94,7 +96,7 @@ Now, use the created test type in your tests.
 
 import { test } from './folio.config';
 
-test('math works?', () => {
+test('check the addition', () => {
   test.expect(1 + 1).toBe(42);
 });
 ```
@@ -120,26 +122,19 @@ import * as folio from 'folio';
 
 folio.setConfig({ testDir: __dirname, timeout: 20000 });
 
-// Type declaration specifies that tests receive a table instance.
-export const test = folio.newTestType<{ table: DatabaseTable }>();
-
 class DatabaseEnv {
-  host: string;
   database: Database;
   table: DatabaseTable;
 
-  constructor(host: string) {
-    this.host = host;
-  }
-
   async beforeAll() {
     // Connect to a database once, it is expensive.
-    this.database = await connectToTestDatabase(this.host);
+    this.database = await connectToTestDatabase();
   }
 
   async beforeEach() {
     // Create a new table for each test and return it.
     this.table = await this.database.createTable();
+    // Anything returned from this method is available to the test. In our case, "table".
     return { table: this.table };
   }
 
@@ -153,12 +148,14 @@ class DatabaseEnv {
   }
 }
 
-// Run our tests in two environments, against a local database and a staging database.
-test.runWith(new DatabaseEnv('localhost:1234'));
-test.runWith(new DatabaseEnv('staging-db.my-company.com:1234'));
+// Our test type comes with the database environment, so each test can use a "table" argument.
+export const test = folio.test.extend(new DatabaseEnv());
+
+// Run our tests.
+test.runWith({ tag: 'database' });
 ```
 
-In this example we see that tests declare the arguments they need, and environment provides the arguments. We can run tests in multiple configurations when needed.
+In this example we see that tests use an environment that provides arguments to the test.
 
 Folio uses worker processes to run test files. You can specify the maximum number of workers using `--workers` command line option. By using `beforeAll` and `afterAll` methods, environment can set up expensive resources to be shared between tests in each worker process. Folio will reuse the worker process for as many test files as it can, provided their environments match.
 
@@ -354,7 +351,6 @@ In addition to everything from the [`workerInfo`](#workerinfo), the following in
 - `retry: number` - The sequential number of the test retry (zero means first run).
 - `expectedStatus: 'passed' | 'failed' | 'timedOut'` - Whether this test is expected to pass, fail or timeout.
 - `timeout: number` - Test timeout.
-- `testOptions` - [Test options](#test-options).
 - `annotations` - [Annotations](#annotations) that were added to the test.
 - `data: object` - Any additional data that you'd like to attach to the test, it will appear in the report.
 - `snapshotPathSegment: string` - Relative path, used to locate snapshots for the test.
@@ -401,6 +397,8 @@ class LogEnv {
 
 Often times there is a need for different kinds of tests, for example generic tests that use a database table, or some specialized tests that require more elaborate setup. It is also common to run tests in multiple configurations. Folio allows you to configure everything by writing code for maximum flexibility.
 
+Instead of using `test.extend()` to add an environment right away, we use `test.declare()` to declare the test arguments and `test.runWith()` to give it the actual environment and configuration.
+
 ```ts
 // folio.config.ts
 
@@ -410,16 +408,6 @@ import * as fs from 'fs';
 // 20 seconds timeout, 3 retries by default.
 folio.setConfig({ testDir: __dirname, timeout: 20000, retries: 3 });
 
-// Define as many test types as you'd like:
-// - Generic test that only needs a string value.
-export const test = folio.newTestType<{ value: string }>();
-// - Slow test for extra-large data sets.
-export const slowTest = folio.newTestType<{ value: string }>();
-// - Smoke tests should not be flaky.
-export const smokeTest = folio.newTestType<{ value: string }>();
-// - Some special tests that require different arguments.
-export const fooTest = folio.newTestType<{ foo: number }>();
-
 // Environment with some test value.
 class MockedEnv {
   async beforeEach() {
@@ -427,7 +415,7 @@ class MockedEnv {
   }
 }
 
-// Another environment that reads from file.
+// Another environment that reads from a file.
 class FileEnv {
   constructor() {
     this.value = fs.readFileSync('data.txt', 'utf8');
@@ -437,24 +425,34 @@ class FileEnv {
   }
 }
 
-// This environment provides foo.
-class FooEnv {
-  async beforeEach() {
-    return { foo: 42 };
-  }
-}
+// Our tests need a common string value.
+const valueTest = folio.test.declare<{ value: string }>();
 
-// Now we can run tests in different configurations:
-// - Generics tests with two different environments.
+// Now declare as many test types as we'd like.
+
+// Run generic tests with two different environments and no specific configuration.
+export const test = valueTest.declare();
 test.runWith(new MockedEnv());
 test.runWith(new FileEnv());
-// - Increased timeout for slow tests.
+
+// Run slow tests with increased timeout, in a single environment.
+export const slowTest = valueTest.declare();
 slowTest.runWith(new MockedEnv(), { timeout: 100000 });
-// - Smoke tests without retries.
-//   Adding a tag allows to run just the smoke tests with `npx folio --tag=smoke`.
+
+// Run smoke tests without retries - these must not be flaky.
+// Adding a tag allows to run just the smoke tests with `npx folio --tag=smoke`.
+export const smokeTest = valueTest.declare();
 smokeTest.runWith(new MockedEnv(), { retries: 0, tag: 'smoke' });
-// - Special foo tests need a different environment.
-fooTest.runWith(new FooEnv());
+
+// These tests also get a "foo" argument.
+export const fooTest = valueTest.extend({
+  beforeEach() {
+    return { foo: 42 };
+  }
+});
+// Although we already added the environment that gives "foo", we still have to provide
+// the "value" declared in valueTest.
+fooTest.runWith(new MockedEnv(), { tag: 'foo' });
 ```
 
 We can now use our test types to write tests:
@@ -539,7 +537,7 @@ class HelloEnv {
 }
 
 // Tests expect a "hello" value.
-export const test = folio.newTestType<{ hello: string }>();
+export const test = folio.test.declare<{ hello: string }>();
 
 // Now, run tests in two configurations.
 test.runWith(new HelloEnv('world'));
@@ -565,9 +563,9 @@ class CreateHelloEnv {
   }
 }
 
-// Tests expect a "createHello" function.
-export const test = folio.newTestType<{ createHello: (name: string) => string }>();
-test.runWith(new CreateHelloEnv());
+// Tests get a "createHello" function.
+export const test = folio.test.extend(new CreateHelloEnv());
+test.runWith();
 ```
 
 Now use this function in the test.
@@ -582,7 +580,7 @@ test('my test', ({ createHello }) => {
 });
 ```
 
-#### Using testInfo.testOptions
+#### Specifying options with `test.useOptions`
 
 Use this method when you have common configuration that needs to often change between tests.
 
@@ -595,34 +593,43 @@ folio.setConfig({ testDir: __dirname });
 
 // This environment provides a "hello".
 class HelloEnv {
-  async beforeEach(testInfo: folio.TestInfo) {
+  // Declare the TestOptions type.
+  testOptionsType(): { name?: string } {
+    return {} as any;  // It does not matter what you return from here.
+  }
+
+  // Use TestOptions in beforeEach.
+  async beforeEach({ name }, testInfo: folio.TestInfo) {
     // Don't forget to account for missing "name".
-    return { hello: `Hello, ${testInfo.testOptions.name || ''}!` };
+    return { hello: `Hello, ${name || ''}!` };
   }
 }
 
 // Tests expect a "hello" value, and can provide a "name" option.
-export const test = folio.newTestType<{ hello: string }, { name: string }>();
-test.runWith(new HelloEnv());
+export const test = folio.test.extend(new HelloEnv());
+test.runWith();
 ```
 
-Now use the options in the test.
+Now specify the options in the test file with `test.useOptions`. It works for each test in the file, or the containing `test.describe` block if any, similar to `test.beforeEach` and other hooks.
 ```ts
 // some.spec.ts
 
 import { test } from './folio.config';
 import { expect } from 'folio';
 
-const options = { name: 'world' };
-test('my test with options', options, ({ hello }) => {
+test.useOptions({ name: 'world' });
+test('my test with options', ({ hello }) => {
   expect(hello).toBe('Hello, world!');
 });
-test('another test, same options', options, ({ hello }) => {
+test('another test, same options', ({ hello }) => {
   expect(hello).toBe('Hello, world!');
 });
 
-test('different options', { name: 'test' }, ({ hello }) => {
-  expect(hello).toBe('Hello, test!');
+test.describe('this suite uses different options', () => {
+  test.useOptions({ name: 'test' });
+  test('different options', ({ hello }) => {
+    expect(hello).toBe('Hello, test!');
+  });
 });
 ```
 
@@ -769,9 +776,7 @@ folio.expect.extend({
   },
 });
 
-export const test = folio.newTestType();
-
-test.runWith();
+folio.test.runWith();
 ```
 </details>
 
@@ -779,8 +784,7 @@ test.runWith();
   <summary>example.spec.ts</summary>
 
 ```ts
-import { test } from '../folio.config';
-import { expect } from 'folio';
+import { expect, test } from 'folio';
 
 test('numeric ranges', () => {
   expect(100).toBeWithinRange(90, 110);

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,8 +15,8 @@
  * limitations under the License.
  */
 
-import type { Env, TestType } from './types';
-import { newTestTypeImpl, mergeEnvsImpl } from './spec';
+import type { TestType } from './types';
+import { newTestTypeImpl } from './spec';
 import DotReporter from './reporters/dot';
 import JSONReporter from './reporters/json';
 import JUnitReporter from './reporters/junit';
@@ -26,18 +26,7 @@ import ListReporter from './reporters/list';
 export * from './types';
 export { expect } from './expect';
 export { setConfig, setReporters, globalSetup, globalTeardown } from './spec';
-
-export function newTestType<TestArgs = {}, TestOptions = {}>(): TestType<TestArgs, TestOptions, TestArgs> {
-  return newTestTypeImpl([]);
-}
-
-export function merge<TestArgs>(env: Env<TestArgs>): Env<TestArgs>;
-export function merge<TestArgs1, TestArgs2>(env1: Env<TestArgs1>, env2: Env<TestArgs2>): Env<TestArgs1 & TestArgs2>;
-export function merge<TestArgs1, TestArgs2, TestArgs3>(env1: Env<TestArgs1>, env2: Env<TestArgs2>, env3: Env<TestArgs3>): Env<TestArgs1 & TestArgs2 & TestArgs3>;
-export function merge(...envs: any): Env<any> {
-  return mergeEnvsImpl(envs);
-}
-
+export const test: TestType<{}, {}, {}, {}> = newTestTypeImpl([]);
 export const reporters = {
   dot: DotReporter,
   json: JSONReporter,

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -16,7 +16,7 @@
 
 import { installTransform } from './transform';
 import { Config, Env, FullConfig, Reporter, TestType } from './types';
-import { prependErrorMessage } from './util';
+import { mergeObjects, prependErrorMessage } from './util';
 import { configFile, setCurrentFile, RunListDescription, setLoadingConfigFile } from './spec';
 import { Suite } from './test';
 
@@ -59,7 +59,7 @@ export class Loader {
 
   addConfig(config: Config) {
     this._layeredConfigs.push({ config });
-    this._mergedConfig = { ...this._mergedConfig, ...config };
+    this._mergedConfig = mergeObjects(this._mergedConfig, config);
   }
 
   loadTestFile(file: string) {
@@ -79,7 +79,7 @@ export class Loader {
   config(runList?: RunListDescription): FullConfig {
     if (!runList)
       return this._mergedConfig;
-    return { ...this._mergedConfig, ...runList.config };
+    return mergeObjects(this._mergedConfig, runList.config);
   }
 
   runLists(): RunListDescription[] {
@@ -91,7 +91,7 @@ export class Loader {
       fileSuites: Map<string, Suite>;
       envs: Env<any>[];
     }>();
-    const visit = (t: TestType<any, any, any>) => {
+    const visit = (t: TestType<any, any, any, any>) => {
       const description = configFile.testTypeDescriptions.get(t)!;
       result.add({ fileSuites: description.fileSuites, envs: description.envs });
       for (const child of description.children)

--- a/src/test.ts
+++ b/src/test.ts
@@ -46,7 +46,6 @@ class Base {
 export class Spec extends Base implements types.Spec {
   fn: Function;
   tests: Test[] = [];
-  testOptions: any = {};
   _ordinalInFile: number;
 
   constructor(title: string, fn: Function, suite: Suite, ordinalInFile: number) {
@@ -74,6 +73,7 @@ export class Spec extends Base implements types.Spec {
 export class Suite extends Base implements types.Suite {
   suites: Suite[] = [];
   specs: Spec[] = [];
+  testOptions: any;
   _entries: (Suite | Spec)[] = [];
   _hooks: { type: string, fn: Function } [] = [];
   _annotations: { type: 'skip' | 'fixme' | 'fail', description?: string }[] = [];

--- a/src/util.ts
+++ b/src/util.ts
@@ -137,3 +137,14 @@ export function createMatcher(patterns: string | RegExp | (string | RegExp)[]): 
     return false;
   };
 }
+
+export function mergeObjects<A extends object, B extends object>(a: A | undefined | void, b: B | undefined | void): A & B {
+  const result = { ...a };
+  if (!Object.is(b, undefined)) {
+    for (const [name, value] of Object.entries(b as B)) {
+      if (!Object.is(value, undefined))
+        result[name] = value;
+    }
+  }
+  return result as any;
+}

--- a/test/access-data.spec.ts
+++ b/test/access-data.spec.ts
@@ -19,13 +19,12 @@ import { test, expect } from './config';
 test('should access error in env', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'folio.config.ts': `
-      const { newTestType } = folio;
       class MyEnv {
-        async afterEach(testInfo) {
+        async afterEach({}, testInfo) {
           console.log('ERROR[[[' + JSON.stringify(testInfo.error, undefined, 2) + ']]]');
         }
       }
-      export const test = newTestType();
+      export const test = folio.test;
       test.runWith(new MyEnv());
     `,
     'test-error-visible-in-env.spec.ts': `
@@ -45,13 +44,12 @@ test('should access error in env', async ({ runInlineTest }) => {
 test('should access data in env', async ({ runInlineTest }) => {
   const { exitCode, report } = await runInlineTest({
     'folio.config.ts': `
-      const { newTestType } = folio;
       class MyEnv {
-        async afterEach(testInfo) {
+        async afterEach({}, testInfo) {
           testInfo.data['myname'] = 'myvalue';
         }
       }
-      export const test = newTestType();
+      export const test = folio.test;
       test.runWith(new MyEnv());
     `,
     'test-data-visible-in-env.spec.ts': `
@@ -74,9 +72,9 @@ test('should access data in env', async ({ runInlineTest }) => {
 test('should report tags in result', async ({ runInlineTest }) => {
   const { exitCode, report } = await runInlineTest({
     'folio.config.ts': `
-      export const test = folio.newTestType();
-      test.runWith({}, { tag: ['foo', 'bar'] });
-      test.runWith(undefined, { tag: 'some tag' });
+      export const test = folio.test;
+      test.runWith({ tag: ['foo', 'bar'] });
+      test.runWith({ tag: 'some tag' });
     `,
     'test-data-visible-in-env.spec.ts': `
       import { test } from './folio.config';

--- a/test/config.spec.ts
+++ b/test/config.spec.ts
@@ -21,7 +21,7 @@ test('should be able to redefine config', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'folio.config.ts': `
       folio.setConfig({ timeout: 12345 });
-      export const test = folio.newTestType();
+      export const test = folio.test;
       test.runWith();
     `,
     'a.test.ts': `
@@ -43,7 +43,7 @@ test('should read config from --config', async ({ runInlineTest }) => {
       folio.setConfig({
         testDir: path.join(__dirname, 'dir'),
       });
-      export const test = folio.newTestType();
+      export const test = folio.test;
       test.runWith();
     `,
     'a.test.ts': `
@@ -72,7 +72,7 @@ test('should be able to setReporters', async ({ runInlineTest }, testInfo) => {
         new folio.reporters.json({ outputFile: ${JSON.stringify(reportFile)}}),
         new folio.reporters.list(),
       ]);
-      export const test = folio.newTestType();
+      export const test = folio.test;
       test.runWith();
     `,
     'a.test.ts': `

--- a/test/config.ts
+++ b/test/config.ts
@@ -55,7 +55,7 @@ async function writeFiles(testInfo: folio.TestInfo, files: Files) {
     files = {
       ...files,
       'folio.config.ts': `
-        export const test = folio.newTestType();
+        export const test = folio.test;
         test.runWith();
       `,
     };

--- a/test/env-errors.spec.ts
+++ b/test/env-errors.spec.ts
@@ -24,7 +24,7 @@ test('should handle env afterEach timeout', async ({ runInlineTest }) => {
           await new Promise(f => setTimeout(f, 100000));
         }
       }
-      export const test = folio.newTestType();
+      export const test = folio.test;
       test.runWith(new MyEnv());
     `,
     'a.spec.ts': `
@@ -51,7 +51,7 @@ test('should handle env afterAll timeout', async ({ runInlineTest }) => {
           await new Promise(f => setTimeout(f, 100000));
         }
       }
-      export const test = folio.newTestType();
+      export const test = folio.test;
       test.runWith(new MyEnv());
     `,
     'a.spec.ts': `
@@ -72,7 +72,7 @@ test('should handle env beforeEach error', async ({ runInlineTest }) => {
           throw new Error('Worker failed');
         }
       }
-      export const test = folio.newTestType();
+      export const test = folio.test;
       test.runWith(new MyEnv());
     `,
     'a.spec.ts': `
@@ -94,7 +94,7 @@ test('should handle env afterAll error', async ({ runInlineTest }) => {
           throw new Error('Worker failed');
         }
       }
-      export const test = folio.newTestType();
+      export const test = folio.test;
       test.runWith(new MyEnv());
     `,
     'a.spec.ts': `
@@ -111,7 +111,7 @@ test('should handle env afterAll error', async ({ runInlineTest }) => {
 test('should throw when test() is called in config file', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'folio.config.ts': `
-      export const test = folio.newTestType();
+      export const test = folio.test;
       test('hey', () => {});
     `,
     'a.test.ts': `
@@ -136,8 +136,8 @@ test('should run afterAll from mulitple envs when one throws', async ({ runInlin
           console.log('env2-afterAll');
         }
       }
-      export const test = folio.newTestType();
-      test.runWith(folio.merge(new MyEnv1(), new MyEnv2()));
+      export const test = folio.test.extend(new MyEnv1()).extend(new MyEnv2());
+      test.runWith();
     `,
     'a.test.ts': `
       import { test } from './folio.config';
@@ -152,12 +152,12 @@ test('should run afterAll from mulitple envs when one throws', async ({ runInlin
 test('can only call runWith in config file', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'folio.config.ts': `
-      export const test = folio.newTestType();
-      test.runWith({});
+      export const test = folio.test;
+      test.runWith();
     `,
     'a.test.ts': `
       import { test } from './folio.config';
-      test.runWith({});
+      test.runWith();
       test('test', async ({}) => {
       });
     `,

--- a/test/expect.spec.ts
+++ b/test/expect.spec.ts
@@ -19,10 +19,6 @@ import { test, expect } from './config';
 test('should be able to extend the expect matchers with test.extend in the folio config', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'folio.config.ts': `
-      folio.setConfig({ timeout: 30000 });
-
-      export const test = folio.newTestType()
-
       folio.expect.extend({
         toBeWithinRange(received, floor, ceiling) {
           const pass = received >= floor && received <= ceiling;
@@ -40,7 +36,7 @@ test('should be able to extend the expect matchers with test.extend in the folio
           }
         },
       });
-
+      export const test = folio.test;
       test.runWith();
     `,
     'expect-test.spec.ts': `

--- a/test/global-setup.spec.ts
+++ b/test/global-setup.spec.ts
@@ -32,7 +32,7 @@ test('globalSetup and globalTeardown should work', async ({ runInlineTest }) => 
       folio.globalSetup(async () => {
         process.env.BAR = 'baz';
       });
-      export const test = folio.newTestType();
+      export const test = folio.test;
       test.runWith();
     `,
     'a.test.js': `
@@ -59,7 +59,7 @@ test('globalTeardown runs after failures', async ({ runInlineTest }) => {
       folio.globalTeardown(() => {
         console.log('teardown=' + value);
       });
-      export const test = folio.newTestType();
+      export const test = folio.test;
       test.runWith();
     `,
     'a.test.js': `
@@ -83,7 +83,7 @@ test('globalTeardown does not run when globalSetup times out', async ({ runInlin
       folio.globalTeardown(() => {
         console.log('teardown=');
       });
-      export const test = folio.newTestType();
+      export const test = folio.test;
       test.runWith();
       folio.setConfig({ globalTimeout: 1000 });
     `,
@@ -107,7 +107,7 @@ test('globalSetup should be run before requiring tests', async ({ runInlineTest 
       folio.globalSetup(async () => {
         process.env.FOO = JSON.stringify({ foo: 'bar' });
       });
-      export const test = folio.newTestType();
+      export const test = folio.test;
       test.runWith();
     `,
     'a.test.js': `

--- a/test/junit-reporter.spec.ts
+++ b/test/junit-reporter.spec.ts
@@ -110,7 +110,7 @@ test('render stdout', async ({ runInlineTest }) => {
 test('render stdout without ansi escapes', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'folio.config.ts': `
-      export const test = folio.newTestType();
+      export const test = folio.test;
       test.runWith();
       folio.setReporters([new folio.reporters.junit({ stripANSIControlSequences: true })]);
     `,

--- a/test/list-reporter.spec.ts
+++ b/test/list-reporter.spec.ts
@@ -19,9 +19,9 @@ import { test, expect, stripAscii } from './config';
 test('render each test with tags', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'folio.config.ts': `
-      export const test = folio.newTestType();
-      test.runWith({ beforeAll: async () => {} }, { tag: 'foo' });
-      test.runWith({ beforeAll: async () => {} }, { tag: 'bar' });
+      export const test = folio.test;
+      test.runWith({ tag: 'foo' });
+      test.runWith({ tag: 'bar' });
     `,
     'a.test.ts': `
       import { test } from './folio.config';

--- a/test/options.spec.ts
+++ b/test/options.spec.ts
@@ -16,16 +16,16 @@
 
 import { test, expect } from './config';
 
-test('should create two suites with different options', async ({ runInlineTest }) => {
+test('should run tests with different options', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'folio.config.ts': `
       global.logs = [];
       class MyEnv {
-        async beforeEach(args, testInfo) {
-          return { foo: testInfo.testOptions.foo || 'foo' };
+        async beforeEach(args) {
+          return { foo: args.foo || 'foo' };
         }
       }
-      export const test = folio.newTestType();
+      export const test = folio.test;
       test.runWith(new MyEnv());
     `,
     'a.test.ts': `
@@ -33,11 +33,19 @@ test('should create two suites with different options', async ({ runInlineTest }
       test('test', ({ foo }) => {
         expect(foo).toBe('foo');
       });
-      test('test1', { foo: 'bar' }, ({ foo }) => {
-        expect(foo).toBe('bar');
-      });
-      test('test2', { foo: 'baz' }, ({ foo }) => {
-        expect(foo).toBe('baz');
+
+      test.describe('suite1', () => {
+        test.useOptions({ foo: 'bar' });
+        test('test1', ({ foo }) => {
+          expect(foo).toBe('bar');
+        });
+
+        test.describe('suite2', () => {
+          test.useOptions({ foo: 'baz' });
+          test('test2', ({ foo }) => {
+            expect(foo).toBe('baz');
+          });
+        });
       });
     `
   });

--- a/test/output-path.spec.ts
+++ b/test/output-path.spec.ts
@@ -49,8 +49,8 @@ test('should include retry token', async ({runInlineTest}) => {
 test('should include tag', async ({runInlineTest}) => {
   const result = await runInlineTest({
     'folio.config.ts': `
-      export const test = folio.newTestType();
-      test.runWith({}, { tag: 'my-title' });
+      export const test = folio.test;
+      test.runWith({ tag: 'my-title' });
     `,
     'a.spec.js': `
       const { test } = require('./folio.config');
@@ -78,9 +78,9 @@ test('should remove output paths', async ({runInlineTest}, testInfo) => {
 
   const result = await runInlineTest({
     'folio.config.js': `
-      exports.test = folio.newTestType();
-      exports.test.runWith(undefined, { outputDir: ${JSON.stringify(paths[0])} });
-      exports.test.runWith(void 0, { outputDir: ${JSON.stringify(paths[2])} });
+      exports.test = folio.test;
+      exports.test.runWith({ outputDir: ${JSON.stringify(paths[0])} });
+      exports.test.runWith({ outputDir: ${JSON.stringify(paths[2])} });
     `,
     'a.test.js': `
       const { test } = require('./folio.config');

--- a/test/override-timeout.spec.ts
+++ b/test/override-timeout.spec.ts
@@ -20,7 +20,7 @@ test('should consider dynamically set value', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'folio.config.js': `
       folio.setConfig({ timeout: 100 });
-      exports.test = folio.newTestType();
+      exports.test = folio.test;
       exports.test.runWith();
     `,
     'a.test.js': `
@@ -38,9 +38,9 @@ test('should allow different timeouts', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'folio.config.js': `
       folio.setConfig({ timeout: 100 });
-      exports.test = folio.newTestType();
-      exports.test.runWith({}, { timeout: 200 });
-      exports.test.runWith({});
+      exports.test = folio.test;
+      exports.test.runWith({ timeout: 200 });
+      exports.test.runWith();
     `,
     'a.test.js': `
       const { test } = require('./folio.config');
@@ -59,7 +59,7 @@ test('should prioritize value set via command line', async ({ runInlineTest }) =
   const result = await runInlineTest({
     'folio.config.js': `
       folio.setConfig({ timeout: 100 });
-      exports.test = folio.newTestType();
+      exports.test = folio.test;
       exports.test.runWith();
     `,
     'a.test.js': `

--- a/test/repeat-each.spec.ts
+++ b/test/repeat-each.spec.ts
@@ -36,9 +36,9 @@ test('should repeat from command line', async ({runInlineTest}) => {
 test('should repeat based on config', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'folio.config.js': `
-      exports.test = folio.newTestType();
-      exports.test.runWith(undefined, { tag: 'no-repeats' });
-      exports.test.runWith({}, { repeatEach: 2, tag: 'two-repeats' });
+      exports.test = folio.test;
+      exports.test.runWith({ tag: 'no-repeats' });
+      exports.test.runWith({ repeatEach: 2, tag: 'two-repeats' });
     `,
     'a.test.js': `
       const { test } = require('./folio.config');

--- a/test/retry.spec.ts
+++ b/test/retry.spec.ts
@@ -40,9 +40,9 @@ test('should retry based on config', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'folio.config.js': `
       folio.setConfig({ retries: 1 });
-      exports.test = folio.newTestType();
-      exports.test.runWith({}, { retries: 0, tag: 'no-retries' });
-      exports.test.runWith({}, { retries: 2, tag: 'two-retries' });
+      exports.test = folio.test;
+      exports.test.runWith({ retries: 0, tag: 'no-retries' });
+      exports.test.runWith({ retries: 2, tag: 'two-retries' });
     `,
     'a.test.js': `
       const { test } = require('./folio.config');
@@ -160,11 +160,11 @@ test('should retry env.beforeAll failure', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'folio.config.ts': `
       class MyEnv {
-        async beforeAll(testInfo) {
+        async beforeAll() {
           throw new Error('env.beforeAll is bugged!');
         }
       }
-      export const test = folio.newTestType();
+      export const test = folio.test;
       test.runWith(new MyEnv());
     `,
     'a.spec.ts': `

--- a/test/stdio.spec.ts
+++ b/test/stdio.spec.ts
@@ -48,7 +48,7 @@ test('should get stdio from env afterAll', async ({runInlineTest}) => {
           console.log('\\n%% worker teardown');
         }
       }
-      export const test = folio.newTestType();
+      export const test = folio.test;
       test.runWith(new MyEnv());
     `,
     'a.spec.js': `

--- a/test/test-ignore.spec.ts
+++ b/test/test-ignore.spec.ts
@@ -94,7 +94,7 @@ test('should use an array for testMatch', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'folio.config.ts': `
       folio.setConfig({ testMatch: ['b.test.ts', /^a.*TS$/i] });
-      export const test = folio.newTestType();
+      export const test = folio.test;
       test.runWith();
     `,
     'a.test.ts': `

--- a/test/test-info.spec.ts
+++ b/test/test-info.spec.ts
@@ -38,7 +38,7 @@ test('should work via env', async ({ runInlineTest }) => {
           return { title: testInfo.title };
         }
       }
-      export const test = folio.newTestType();
+      export const test = folio.test;
       test.runWith(new MyEnv());
     `,
     'a.test.js': `

--- a/test/test-output-dir.spec.ts
+++ b/test/test-output-dir.spec.ts
@@ -55,8 +55,8 @@ test('should include runWith tag', async ({ runInlineTest }) => {
           return {};
         }
       }
-      export const test = folio.newTestType();
-      export const test2 = folio.newTestType();
+      export const test = folio.test.extend();
+      export const test2 = folio.test.extend();
       test.runWith(new Env('snapshots1'), { tag: 'foo' });
       test.runWith(new Env('snapshots2'), { tag: 'foo' });
       test2.runWith(new Env('snapshots1'), { tag: 'foo' });

--- a/test/timeout.spec.ts
+++ b/test/timeout.spec.ts
@@ -20,11 +20,11 @@ test('should run env afterEach on timeout', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'folio.config.ts': `
       class MyEnv {
-        async afterEach(testInfo) {
+        async afterEach({}, testInfo) {
           console.log('STATUS:' + testInfo.status);
         }
       }
-      export const test = folio.newTestType();
+      export const test = folio.test;
       test.runWith(new MyEnv());
     `,
     'c.spec.ts': `

--- a/test/types-2.spec.ts
+++ b/test/types-2.spec.ts
@@ -60,55 +60,29 @@ test('can return anything from hooks', async ({runTSC}) => {
 test('test.declare should check types', async ({runTSC}) => {
   const result = await runTSC({
     'folio.config.ts': `
-      export const test = folio.newTestType();
-      const x: number = '123';  // To match line numbers easier.
+      export const test = folio.test;
       export const test1 = test.declare<{ foo: string }>();
       export const test2 = test1.extend({ beforeEach: ({ foo }) => { return { bar: parseInt(foo) }; } });
       test.runWith({});
-      test1.runWith({});  // error
-      test1.runWith({ beforeEach: () => { return { foo: 'foo' }; }});
-      test1.runWith({ beforeEach: () => { return { foo: 42 }; }});  // error
-      test2.runWith({});  // error
-      test2.runWith({ beforeEach: () => { return { foo: 'foo' }; }});
+      test1.runWith({});
+      test2.runWith({});
       export const test3 = test1.declare<{ baz: number }>();
-      test3.runWith({ beforeEach: () => { return { foo: 'foo' }; }});  // error
-      test3.runWith({ beforeEach: ({ baz }) => { return { foo: 'foo', baz: 42 }; }});  // error
-      test3.runWith({ beforeEach: () => { return { foo: 'foo', baz: 42 }; }});
+      test3.runWith({});
     `,
     'a.spec.ts': `
       import { test, test1, test2, test3 } from './folio.config';
-      const x: number = '123';  // To match line numbers easier.
-      test('my test', async ({ foo }) => {});  // error
+      // @ts-expect-error
+      test('my test', async ({ foo }) => {});
       test1('my test', async ({ foo }) => {});
-      test1('my test', async ({ foo, bar }) => {});  // error
+      // @ts-expect-error
+      test1('my test', async ({ foo, bar }) => {});
       test2('my test', async ({ foo, bar }) => {});
       test3('my test', async ({ foo, baz }) => {});
-      test3('my test', async ({ foo, bar }) => {});  // error
-      test2('my test', async ({ foo, baz }) => {});  // error
+      // @ts-expect-error
+      test3('my test', async ({ foo, bar }) => {});
+      // @ts-expect-error
+      test2('my test', async ({ foo, baz }) => {});
     `
   });
-  expect(result.exitCode).not.toBe(0);
-
-  expect(result.output).toContain(`folio.config.ts(5,13): error TS2322: Type 'string' is not assignable to type 'number'.`);
-  expect(result.output).not.toContain('folio.config.ts(6');
-  expect(result.output).not.toContain('folio.config.ts(7');
-  expect(result.output).not.toContain('folio.config.ts(8');
-  expect(result.output).toContain('folio.config.ts(9');
-  expect(result.output).not.toContain('folio.config.ts(10');
-  expect(result.output).toContain('folio.config.ts(11');
-  expect(result.output).toContain('folio.config.ts(12');
-  expect(result.output).not.toContain('folio.config.ts(13');
-  expect(result.output).not.toContain('folio.config.ts(14');
-  expect(result.output).toContain('folio.config.ts(15');
-  expect(result.output).toContain('folio.config.ts(16');
-  expect(result.output).not.toContain('folio.config.ts(17');
-
-  expect(result.output).toContain(`a.spec.ts(6,13): error TS2322: Type 'string' is not assignable to type 'number'.`);
-  expect(result.output).toContain('a.spec.ts(7');
-  expect(result.output).not.toContain('a.spec.ts(8');
-  expect(result.output).toContain('a.spec.ts(9');
-  expect(result.output).not.toContain('a.spec.ts(10');
-  expect(result.output).not.toContain('a.spec.ts(11');
-  expect(result.output).toContain('a.spec.ts(12');
-  expect(result.output).toContain('a.spec.ts(13');
+  expect(result.exitCode).toBe(0);
 });

--- a/test/worker-index.spec.ts
+++ b/test/worker-index.spec.ts
@@ -69,7 +69,7 @@ test('should reuse worker for multiple tests', async ({ runInlineTest }) => {
 test('should not reuse worker for different suites', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'folio.config.ts': `
-      export const test = folio.newTestType();
+      export const test = folio.test;
       test.runWith();
       test.runWith();
       test.runWith();


### PR DESCRIPTION
- Removed `newTestType`. Use `folio.test.declare<T>()` instead.
- Removed `folio.merge`. Now `runWith` only accepts a single env.
- Introduced `options` and `testOptions` as arguments available to `env.beforeAll` and `env.beforeEach` respectively.
- Replaced `testOptions` parameter from `test` with `test.useOptions()`.
- A lot of type changes.