### PR TITLE
feat: rename environment methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,24 +127,24 @@ class DatabaseEnv {
   database: Database;
   table: DatabaseTable;
 
-  async beforeAll() {
-    // Connect to a database once, it is expensive.
+  async setupWorker() {
+    // Connect to a database once per worker, it is expensive.
     this.database = await connectToTestDatabase();
   }
 
-  async beforeEach() {
+  async setupTest() {
     // Create a new table for each test and return it.
     this.table = await this.database.createTable();
     // Anything returned from this method is available to the test. In our case, "table".
     return { table: this.table };
   }
 
-  async afterEach() {
+  async teardownTest() {
     // Do not leave extra tables around.
     await this.table.drop();
   }
 
-  async afterAll() {
+  async teardownWorker() {
     await this.database.disconnect();
   }
 }
@@ -158,7 +158,7 @@ test.runWith({ tag: 'database' });
 
 In this example we see that tests use an environment that provides arguments to the test.
 
-Folio uses worker processes to run test files. You can specify the maximum number of workers using `--workers` command line option. By using `beforeAll` and `afterAll` methods, environment can set up expensive resources to be shared between tests in each worker process. Folio will reuse the worker process for as many test files as it can, provided their environments match.
+Folio uses worker processes to run test files. You can specify the maximum number of workers using `--workers` command line option. By using `setupWorker` and `teardownWorker` methods, environment can set up expensive resources to be shared between tests in each worker process. Folio will reuse the worker process for as many test files as it can, provided their environments match.
 
 ## Annotations
 
@@ -345,7 +345,7 @@ test('my test', async () => {
 
 Depending on the configuration and failures, Folio might use different number of worker processes to run all the tests. For example, Folio will always start a new worker process after a failing test.
 
-Environment and hooks receive `workerInfo` in the `beforeAll` and `afterAll` calls. The following information is accessible from the `workerInfo`:
+`workerInfo` object is available as a second parameter in `beforeAll` hooks, `afterAll` hooks, `setupWorker` and `teardownWorker` environment methods. The following information is accessible from the `workerInfo`:
 - `config` - [Configuration object](#configuration-object).
 - `workerIndex: number` - A unique sequential index assigned to the worker process.
 
@@ -357,18 +357,18 @@ import * as http from 'http';
 class ServerEnv {
   server: http.Server;
 
-  async beforeAll(workerInfo) {
+  async setupWorker(workerInfo) {
     this.server = http.createServer();
     this.server.listen(9000 + workerInfo.workerIndex);
     await new Promise(ready => this.server.once('listening', ready));
   }
 
-  async beforeEach() {
+  async setupTest() {
     // Provide the server as a test argument.
     return { server: this.server };
   }
 
-  async afterAll() {
+  async teardownWorker() {
     await new Promise(done => this.server.close(done));
   }
 }
@@ -376,7 +376,7 @@ class ServerEnv {
 
 ### testInfo
 
-Environment and hooks receive `testInfo` in the `beforeEach` and `afterEach` calls. It is also available to the test function as a second parameter.
+`testInfo` object is available as a second parameter in test functions, `beforeEach` hooks, `afterEach` hooks, `setupTest` and `teardownTest` environment methods.
 
 In addition to everything from the [`workerInfo`](#workerinfo), the following information is accessible before and during the test:
 - `title: string` - Test title.
@@ -418,13 +418,13 @@ import * as debug from 'debug';
 import * as fs from 'fs';
 
 class LogEnv {
-  async beforeEach() {
+  async setupTest() {
     this.logs = [];
     debug.log = (...args) => this.logs.push(args.map(String).join(''));
     debug.enable('mycomponent');
   }
 
-  async afterEach(testInfo) {
+  async teardownTest(testInfo) {
     if (testInfo.status !== testInfo.expectedStatus)
       fs.writeFileSync(testInfo.outputPath('logs.txt'), this.logs.join('\n'), 'utf8');
   }
@@ -448,7 +448,7 @@ folio.setConfig({ testDir: __dirname, timeout: 20000, retries: 3 });
 
 // Environment with some test value.
 class MockedEnv {
-  async beforeEach() {
+  async setupTest() {
     return { value: 'some test value' };
   }
 }
@@ -458,7 +458,7 @@ class FileEnv {
   constructor() {
     this.value = fs.readFileSync('data.txt', 'utf8');
   }
-  async beforeEach() {
+  async setupTest() {
     return { value: this.value };
   }
 }
@@ -484,7 +484,7 @@ smokeTest.runWith(new MockedEnv(), { retries: 0, tag: 'smoke' });
 
 // These tests also get a "foo" argument.
 export const fooTest = valueTest.extend({
-  beforeEach() {
+  setupTest() {
     return { foo: 42 };
   }
 });
@@ -569,7 +569,7 @@ class HelloEnv {
     this.name = name;
   }
 
-  async beforeEach() {
+  async setupTest() {
     return { hello: `Hello, ${this.name}!` };
   }
 }
@@ -596,7 +596,7 @@ folio.setConfig({ testDir: __dirname });
 
 // This environment provides a function "createHello".
 class CreateHelloEnv {
-  async beforeEach() {
+  async setupTest() {
     return { createHello: (name: string) => `Hello, ${name}!` };
   }
 }
@@ -636,8 +636,8 @@ class HelloEnv {
     return {} as any;  // It does not matter what you return from here.
   }
 
-  // Use TestOptions in beforeEach.
-  async beforeEach({ name }, testInfo: folio.TestInfo) {
+  // Use TestOptions in setupTest.
+  async setupTest({ name }, testInfo: folio.TestInfo) {
     // Don't forget to account for missing "name".
     return { hello: `Hello, ${name || ''}!` };
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -150,13 +150,13 @@ type RemovePromise<T> = T extends Promise<infer R> ? R : T;
 export interface Env<TestArgs = {}, WorkerArgs = {}, TestOptions = {}, WorkerOptions = {}, PreviousTestArgs = {}, PreviousWorkerArgs = {}> {
   // For type inference.
   testOptionsType?(): TestOptions;
-  optionsType?(): WorkerOptions;
+  workerOptionsType?(): WorkerOptions;
 
   // Implementation.
-  beforeEach?(args: PreviousTestArgs & TestOptions, testInfo: TestInfo): MaybePromise<MaybeVoid<TestArgs>>;
-  beforeAll?(args: PreviousWorkerArgs & WorkerOptions, workerInfo: WorkerInfo): MaybePromise<MaybeVoid<WorkerArgs>>;
-  afterEach?(args: this['beforeEach'] extends undefined ? TestArgs : RemovePromise<ReturnType<Exclude<this['beforeEach'], undefined>>>, testInfo: TestInfo): MaybePromise<any>;
-  afterAll?(args: this['beforeAll'] extends undefined ? WorkerArgs : RemovePromise<ReturnType<Exclude<this['beforeAll'], undefined>>>, workerInfo: WorkerInfo): MaybePromise<any>;
+  setupWorker?(args: PreviousWorkerArgs & WorkerOptions, workerInfo: WorkerInfo): MaybePromise<MaybeVoid<WorkerArgs>>;
+  teardownWorker?(args: this['setupWorker'] extends undefined ? WorkerArgs : RemovePromise<ReturnType<Exclude<this['setupWorker'], undefined>>>, workerInfo: WorkerInfo): MaybePromise<any>;
+  setupTest?(args: PreviousTestArgs & TestOptions, testInfo: TestInfo): MaybePromise<MaybeVoid<TestArgs>>;
+  teardownTest?(args: this['setupTest'] extends undefined ? TestArgs : RemovePromise<ReturnType<Exclude<this['setupTest'], undefined>>>, testInfo: TestInfo): MaybePromise<any>;
 }
 
 // ---------- Reporters API -----------

--- a/test/access-data.spec.ts
+++ b/test/access-data.spec.ts
@@ -20,7 +20,7 @@ test('should access error in env', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'folio.config.ts': `
       class MyEnv {
-        async afterEach({}, testInfo) {
+        async teardownTest({}, testInfo) {
           console.log('ERROR[[[' + JSON.stringify(testInfo.error, undefined, 2) + ']]]');
         }
       }
@@ -45,7 +45,7 @@ test('should access data in env', async ({ runInlineTest }) => {
   const { exitCode, report } = await runInlineTest({
     'folio.config.ts': `
       class MyEnv {
-        async afterEach({}, testInfo) {
+        async teardownTest({}, testInfo) {
           testInfo.data['myname'] = 'myvalue';
         }
       }

--- a/test/env-errors.spec.ts
+++ b/test/env-errors.spec.ts
@@ -16,11 +16,11 @@
 
 import { test, expect, stripAscii } from './config';
 
-test('should handle env afterEach timeout', async ({ runInlineTest }) => {
+test('should handle teardownTest timeout', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'folio.config.ts': `
       class MyEnv {
-        async afterEach() {
+        async teardownTest() {
           await new Promise(f => setTimeout(f, 100000));
         }
       }
@@ -43,11 +43,11 @@ test('should handle env afterEach timeout', async ({ runInlineTest }) => {
   expect(result.failed).toBe(2);
 });
 
-test('should handle env afterAll timeout', async ({ runInlineTest }) => {
+test('should handle teardownWorker timeout', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'folio.config.ts': `
       class MyEnv {
-        async afterAll() {
+        async teardownWorker() {
           await new Promise(f => setTimeout(f, 100000));
         }
       }
@@ -64,11 +64,11 @@ test('should handle env afterAll timeout', async ({ runInlineTest }) => {
   expect(result.output).toContain('Timeout of 500ms');
 });
 
-test('should handle env beforeEach error', async ({ runInlineTest }) => {
+test('should handle env setupTest error', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'folio.config.ts': `
       class MyEnv {
-        async beforeEach() {
+        async setupTest() {
           throw new Error('Worker failed');
         }
       }
@@ -86,11 +86,11 @@ test('should handle env beforeEach error', async ({ runInlineTest }) => {
   expect(result.output).toContain('Worker failed');
 });
 
-test('should handle env afterAll error', async ({ runInlineTest }) => {
+test('should handle teardownWorker error', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'folio.config.ts': `
       class MyEnv {
-        async afterAll() {
+        async teardownWorker() {
           throw new Error('Worker failed');
         }
       }
@@ -123,17 +123,17 @@ test('should throw when test() is called in config file', async ({ runInlineTest
   expect(stripAscii(result.output)).toContain('Test can only be defined in a test file.');
 });
 
-test('should run afterAll from mulitple envs when one throws', async ({ runInlineTest }) => {
+test('should run teardownWorker from mulitple envs when one throws', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'folio.config.ts': `
       class MyEnv1 {
-        async afterAll() {
+        async teardownWorker() {
           throw new Error('Bad env');
         }
       }
       class MyEnv2 {
-        async afterAll() {
-          console.log('env2-afterAll');
+        async teardownWorker() {
+          console.log('env2-teardownWorker');
         }
       }
       export const test = folio.test.extend(new MyEnv1()).extend(new MyEnv2());
@@ -146,7 +146,7 @@ test('should run afterAll from mulitple envs when one throws', async ({ runInlin
     `,
   });
   expect(result.output).toContain('Bad env');
-  expect(result.output).toContain('env2-afterAll');
+  expect(result.output).toContain('env2-teardownWorker');
 });
 
 test('can only call runWith in config file', async ({ runInlineTest }) => {

--- a/test/env.spec.ts
+++ b/test/env.spec.ts
@@ -21,24 +21,24 @@ test('env should work', async ({ runInlineTest }) => {
     'folio.config.ts': `
       global.logs = [];
       class MyEnv {
-        async beforeAll() {
-          global.logs.push('beforeAll');
+        async setupWorker() {
+          global.logs.push('setupWorker');
           return { x: 1 };
         }
-        async afterAll({ x }) {
+        async teardownWorker({ x }) {
           if (x !== 1)
             throw new Error('expected 1');
-          global.logs.push('afterAll');
+          global.logs.push('teardownWorker');
           console.log(global.logs.join('\\n'));
         }
-        async beforeEach() {
-          global.logs.push('beforeEach');
+        async setupTest() {
+          global.logs.push('setupTest');
           return { foo: 'bar' };
         }
-        async afterEach({ foo }) {
+        async teardownTest({ foo }) {
           if (foo !== 'bar')
             throw new Error('expected bar');
-          global.logs.push('afterEach');
+          global.logs.push('teardownTest');
         }
       }
       export const test = folio.test;
@@ -57,7 +57,7 @@ test('env should work', async ({ runInlineTest }) => {
     `,
   });
   expect(results[0].status).toBe('passed');
-  expect(output).toContain('beforeAll\nbeforeEach\ntest1\nafterEach\nbeforeEach\ntest2\nafterEach\nafterAll');
+  expect(output).toContain('setupWorker\nsetupTest\ntest1\nteardownTest\nsetupTest\ntest2\nteardownTest\nteardownWorker');
 });
 
 const multipleEnvs = {
@@ -67,19 +67,19 @@ const multipleEnvs = {
       constructor(suffix) {
         this.suffix = suffix;
       }
-      async beforeAll() {
-        global.logs.push('beforeAll' + this.suffix);
+      async setupWorker() {
+        global.logs.push('setupWorker' + this.suffix);
       }
-      async afterAll() {
-        global.logs.push('afterAll' + this.suffix);
+      async teardownWorker() {
+        global.logs.push('teardownWorker' + this.suffix);
         console.log(global.logs.join('\\n'));
       }
-      async beforeEach() {
-        global.logs.push('beforeEach' + this.suffix);
+      async setupTest() {
+        global.logs.push('setupTest' + this.suffix);
         return { foo: 'bar' };
       }
-      async afterEach() {
-        global.logs.push('afterEach' + this.suffix);
+      async teardownTest() {
+        global.logs.push('teardownTest' + this.suffix);
       }
     }
     exports.fooTest = folio.test.declare();
@@ -109,17 +109,17 @@ test('multiple envs and suites should work', async ({ runInlineTest }) => {
   const { passed, failed, output } = await runInlineTest(multipleEnvs);
   expect(passed).toBe(4);
   expect(failed).toBe(0);
-  expect(output).toContain('beforeAll-env1\nbeforeEach-env1\nfooTest\nafterEach-env1\nafterAll-env1');
-  expect(output).toContain('beforeAll-env2\nbeforeEach-env2\nfooTest\nafterEach-env2\nafterAll-env2');
-  expect(output).toContain('beforeAll-env3\nbeforeEach-env3\nbarTest1\nafterEach-env3\nbeforeEach-env3\nbarTest2\nafterEach-env3\nafterAll-env3');
+  expect(output).toContain('setupWorker-env1\nsetupTest-env1\nfooTest\nteardownTest-env1\nteardownWorker-env1');
+  expect(output).toContain('setupWorker-env2\nsetupTest-env2\nfooTest\nteardownTest-env2\nteardownWorker-env2');
+  expect(output).toContain('setupWorker-env3\nsetupTest-env3\nbarTest1\nteardownTest-env3\nsetupTest-env3\nbarTest2\nteardownTest-env3\nteardownWorker-env3');
 });
 
 test('should filter by tag', async ({ runInlineTest }) => {
   const { passed, failed, output } = await runInlineTest(multipleEnvs, { tag: ['suite2', 'suite1'] });
   expect(passed).toBe(2);
   expect(failed).toBe(0);
-  expect(output).toContain('beforeAll-env1\nbeforeEach-env1\nfooTest\nafterEach-env1\nafterAll-env1');
-  expect(output).toContain('beforeAll-env2\nbeforeEach-env2\nfooTest\nafterEach-env2\nafterAll-env2');
+  expect(output).toContain('setupWorker-env1\nsetupTest-env1\nfooTest\nteardownTest-env1\nteardownWorker-env1');
+  expect(output).toContain('setupWorker-env2\nsetupTest-env2\nfooTest\nteardownTest-env2\nteardownWorker-env2');
 });
 
 test('should teardown env after timeout', async ({ runInlineTest }, testInfo) => {
@@ -128,11 +128,11 @@ test('should teardown env after timeout', async ({ runInlineTest }, testInfo) =>
   const result = await runInlineTest({
     'folio.config.ts': `
       class MyEnv {
-        async afterAll() {
-          require('fs').appendFileSync(process.env.TEST_FILE, 'afterAll\\n', 'utf8');
+        async teardownWorker() {
+          require('fs').appendFileSync(process.env.TEST_FILE, 'teardownWorker\\n', 'utf8');
         }
-        async afterEach() {
-          require('fs').appendFileSync(process.env.TEST_FILE, 'afterEach\\n', 'utf8');
+        async teardownTest() {
+          require('fs').appendFileSync(process.env.TEST_FILE, 'teardownTest\\n', 'utf8');
         }
       }
       export const test = folio.test;
@@ -147,8 +147,8 @@ test('should teardown env after timeout', async ({ runInlineTest }, testInfo) =>
   }, { timeout: 1000 }, { TEST_FILE: file });
   expect(result.results[0].status).toBe('timedOut');
   const content = require('fs').readFileSync(file, 'utf8');
-  expect(content).toContain('afterEach');
-  expect(content).toContain('afterAll');
+  expect(content).toContain('teardownTest');
+  expect(content).toContain('teardownWorker');
 });
 
 test('should initialize env once across files', async ({ runInlineTest }) => {
@@ -156,11 +156,11 @@ test('should initialize env once across files', async ({ runInlineTest }) => {
     'folio.config.js': `
       global.logs = [];
       class MyEnv {
-        async beforeAll() {
-          global.logs.push('beforeAll');
+        async setupWorker() {
+          global.logs.push('setupWorker');
         }
-        async afterAll() {
-          global.logs.push('afterAll');
+        async teardownWorker() {
+          global.logs.push('teardownWorker');
           console.log(global.logs.join('\\n'));
         }
       }
@@ -182,23 +182,23 @@ test('should initialize env once across files', async ({ runInlineTest }) => {
   }, { workers: 1 });
   expect(passed).toBe(2);
   expect(failed).toBe(0);
-  expect(output).toContain('beforeAll\ntest1\ntest2\nafterAll');
+  expect(output).toContain('setupWorker\ntest1\ntest2\nteardownWorker');
 });
 
 test('should run sync env methods and hooks', async ({ runInlineTest }) => {
   const { passed } = await runInlineTest({
     'folio.config.ts': `
       class Env {
-        beforeAll() {
+        setupWorker() {
           this.counter = 0;
         }
-        beforeEach() {
+        setupTest() {
           return { counter: this.counter };
         }
-        afterEach() {
+        teardownTest() {
           this.counter++;
         }
-        afterAll() {
+        teardownWorker() {
         }
       }
       export const test = folio.test;

--- a/test/hooks.spec.ts
+++ b/test/hooks.spec.ts
@@ -21,18 +21,18 @@ test('hooks should work with env', async ({ runInlineTest }) => {
     'folio.config.ts': `
       global.logs = [];
       class MyEnv {
-        async beforeAll() {
+        async setupWorker() {
           global.logs.push('+w');
           return { w: 17 };
         }
-        async afterAll() {
+        async teardownWorker() {
           global.logs.push('-w');
         }
-        async beforeEach() {
+        async setupTest() {
           global.logs.push('+t');
           return { t: 42 };
         }
-        async afterEach() {
+        async teardownTest() {
           global.logs.push('-t');
         }
       }
@@ -85,10 +85,10 @@ test('afterEach failure should not prevent other hooks and env teardown', async 
     'folio.config.ts': `
       global.logs = [];
       class MyEnv {
-        async beforeEach() {
+        async setupTest() {
           console.log('+t');
         }
-        async afterEach() {
+        async teardownTest() {
           console.log('-t');
         }
       }

--- a/test/options.spec.ts
+++ b/test/options.spec.ts
@@ -21,7 +21,7 @@ test('should run tests with different options', async ({ runInlineTest }) => {
     'folio.config.ts': `
       global.logs = [];
       class MyEnv {
-        async beforeEach(args) {
+        async setupTest(args) {
           return { foo: args.foo || 'foo' };
         }
       }

--- a/test/retry.spec.ts
+++ b/test/retry.spec.ts
@@ -156,12 +156,12 @@ test('should retry beforeAll failure', async ({ runInlineTest }) => {
   expect(result.output).toContain('BeforeAll is bugged!');
 });
 
-test('should retry env.beforeAll failure', async ({ runInlineTest }) => {
+test('should retry setupWorker failure', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'folio.config.ts': `
       class MyEnv {
-        async beforeAll() {
-          throw new Error('env.beforeAll is bugged!');
+        async setupWorker() {
+          throw new Error('setupWorker is bugged!');
         }
       }
       export const test = folio.test;
@@ -177,5 +177,5 @@ test('should retry env.beforeAll failure', async ({ runInlineTest }) => {
   expect(result.passed).toBe(0);
   expect(result.failed).toBe(1);
   expect(stripAscii(result.output).split('\n')[0]).toBe('××F');
-  expect(result.output).toContain('env.beforeAll is bugged!');
+  expect(result.output).toContain('setupWorker is bugged!');
 });

--- a/test/stdio.spec.ts
+++ b/test/stdio.spec.ts
@@ -37,14 +37,14 @@ test('should get top level stdio', async ({runInlineTest}) => {
   ]);
 });
 
-test('should get stdio from env afterAll', async ({runInlineTest}) => {
+test('should get stdio from teardownWorker', async ({runInlineTest}) => {
   const result = await runInlineTest({
     'folio.config.ts': `
       class MyEnv {
-        async beforeAll() {
+        async setupWorker() {
           console.log('\\n%% worker setup');
         }
-        async afterAll() {
+        async teardownWorker() {
           console.log('\\n%% worker teardown');
         }
       }

--- a/test/test-extend.spec.ts
+++ b/test/test-extend.spec.ts
@@ -24,20 +24,20 @@ test('test.extend should work', async ({ runInlineTest }) => {
         constructor(suffix) {
           this.suffix = suffix;
         }
-        async beforeAll() {
-          global.logs.push('beforeAll' + this.suffix);
+        async setupWorker() {
+          global.logs.push('setupWorker' + this.suffix);
         }
-        async afterAll() {
-          global.logs.push('afterAll' + this.suffix);
+        async teardownWorker() {
+          global.logs.push('teardownWorker' + this.suffix);
           if (this.suffix.includes('base'))
             console.log(global.logs.join('\\n'));
         }
-        async beforeEach() {
-          global.logs.push('beforeEach' + this.suffix);
+        async setupTest() {
+          global.logs.push('setupTest' + this.suffix);
           return { foo: 'bar' };
         }
-        async afterEach() {
-          global.logs.push('afterEach' + this.suffix);
+        async teardownTest() {
+          global.logs.push('teardownTest' + this.suffix);
         }
       }
       export const base = folio.test;
@@ -63,48 +63,48 @@ test('test.extend should work', async ({ runInlineTest }) => {
   });
   expect(passed).toBe(4);
   expect(output).toContain([
-    'beforeAll-base1',
-    'beforeAll-e1',
-    'beforeEach-base1',
-    'beforeEach-e1',
+    'setupWorker-base1',
+    'setupWorker-e1',
+    'setupTest-base1',
+    'setupTest-e1',
     'test1',
-    'afterEach-e1',
-    'afterEach-base1',
-    'afterAll-e1',
-    'afterAll-base1',
+    'teardownTest-e1',
+    'teardownTest-base1',
+    'teardownWorker-e1',
+    'teardownWorker-base1',
   ].join('\n'));
   expect(output).toContain([
-    'beforeAll-base1',
-    'beforeAll-e2',
-    'beforeEach-base1',
-    'beforeEach-e2',
+    'setupWorker-base1',
+    'setupWorker-e2',
+    'setupTest-base1',
+    'setupTest-e2',
     'test2',
-    'afterEach-e2',
-    'afterEach-base1',
-    'afterAll-e2',
-    'afterAll-base1',
+    'teardownTest-e2',
+    'teardownTest-base1',
+    'teardownWorker-e2',
+    'teardownWorker-base1',
   ].join('\n'));
   expect(output).toContain([
-    'beforeAll-base2',
-    'beforeAll-e1',
-    'beforeEach-base2',
-    'beforeEach-e1',
+    'setupWorker-base2',
+    'setupWorker-e1',
+    'setupTest-base2',
+    'setupTest-e1',
     'test1',
-    'afterEach-e1',
-    'afterEach-base2',
-    'afterAll-e1',
-    'afterAll-base2',
+    'teardownTest-e1',
+    'teardownTest-base2',
+    'teardownWorker-e1',
+    'teardownWorker-base2',
   ].join('\n'));
   expect(output).toContain([
-    'beforeAll-base2',
-    'beforeAll-e2',
-    'beforeEach-base2',
-    'beforeEach-e2',
+    'setupWorker-base2',
+    'setupWorker-e2',
+    'setupTest-base2',
+    'setupTest-e2',
     'test2',
-    'afterEach-e2',
-    'afterEach-base2',
-    'afterAll-e2',
-    'afterAll-base2',
+    'teardownTest-e2',
+    'teardownTest-base2',
+    'teardownWorker-e2',
+    'teardownWorker-base2',
   ].join('\n'));
 });
 
@@ -112,12 +112,12 @@ test('test.extend should work with plain object syntax', async ({ runInlineTest 
   const { output, passed } = await runInlineTest({
     'folio.config.ts': `
       export const test = folio.test.extend({
-        async beforeEach() {
+        async setupTest() {
           this.foo = 'bar';
           return { foo: this.foo };
         },
-        afterEach({}, testInfo) {
-          console.log('afterEach=' + this.foo + ';' + testInfo.title);
+        teardownTest({}, testInfo) {
+          console.log('teardownTest=' + this.foo + ';' + testInfo.title);
         },
       });
       test.runWith();
@@ -130,7 +130,7 @@ test('test.extend should work with plain object syntax', async ({ runInlineTest 
     `,
   });
   expect(passed).toBe(1);
-  expect(output).toContain('afterEach=bar;test1');
+  expect(output).toContain('teardownTest=bar;test1');
 });
 
 test('test.declare should fork', async ({ runInlineTest }) => {
@@ -161,52 +161,52 @@ test('test.extend should chain worker and test args', async ({ runInlineTest }) 
     'folio.config.ts': `
       global.logs = [];
       export class Env1 {
-        async beforeAll() {
-          global.logs.push('beforeAll1');
+        async setupWorker() {
+          global.logs.push('setupWorker1');
           return { w1: 'w1' };
         }
-        async afterAll({ w1 }) {
-          global.logs.push('afterAll1-w1=' + w1);
+        async teardownWorker({ w1 }) {
+          global.logs.push('teardownWorker1-w1=' + w1);
           console.log(global.logs.join('\\n'));
         }
-        async beforeEach() {
-          global.logs.push('beforeEach1');
+        async setupTest() {
+          global.logs.push('setupTest1');
           return { t1: 't1' };
         }
-        async afterEach({ t1 }) {
-          global.logs.push('afterEach1-t1=' + t1);
+        async teardownTest({ t1 }) {
+          global.logs.push('teardownTest1-t1=' + t1);
         }
       }
       export class Env2 {
-        async beforeAll({ w1 }) {
-          global.logs.push('beforeAll2-w1=' + w1);
+        async setupWorker({ w1 }) {
+          global.logs.push('setupWorker2-w1=' + w1);
           return { w2: 'w2' };
         }
-        async afterAll({ w1, w2 }) {
-          global.logs.push('afterAll2-w1=' + w1 + ',w2=' + w2);
+        async teardownWorker({ w1, w2 }) {
+          global.logs.push('teardownWorker2-w1=' + w1 + ',w2=' + w2);
         }
-        async beforeEach({ t1 }) {
-          global.logs.push('beforeEach2-t1=' + t1);
+        async setupTest({ t1 }) {
+          global.logs.push('setupTest2-t1=' + t1);
           return { t2: 't2' };
         }
-        async afterEach({ t1, t2 }) {
-          global.logs.push('afterEach2-t1=' + t1 + ',t2=' + t2);
+        async teardownTest({ t1, t2 }) {
+          global.logs.push('teardownTest2-t1=' + t1 + ',t2=' + t2);
         }
       }
       export class Env3 {
-        async beforeAll({ w1, w2 }) {
-          global.logs.push('beforeAll3-w1=' + w1 + ',w2=' + w2);
+        async setupWorker({ w1, w2 }) {
+          global.logs.push('setupWorker3-w1=' + w1 + ',w2=' + w2);
           return { w3: 'w3' };
         }
-        async afterAll({ w1, w2, w3 }) {
-          global.logs.push('afterAll3-w1=' + w1 + ',w2=' + w2 + ',w3=' + w3);
+        async teardownWorker({ w1, w2, w3 }) {
+          global.logs.push('teardownWorker3-w1=' + w1 + ',w2=' + w2 + ',w3=' + w3);
         }
-        async beforeEach({ t1, t2}) {
-          global.logs.push('beforeEach3-t1=' + t1 + ',t2=' + t2);
+        async setupTest({ t1, t2}) {
+          global.logs.push('setupTest3-t1=' + t1 + ',t2=' + t2);
           return { t3: 't3' };
         }
-        async afterEach({ t1, t2, t3 }) {
-          global.logs.push('afterEach3-t1=' + t1 + ',t2=' + t2 + ',t3=' + t3);
+        async teardownTest({ t1, t2, t3 }) {
+          global.logs.push('teardownTest3-t1=' + t1 + ',t2=' + t2 + ',t3=' + t3);
         }
       }
       export const test = folio.test.declare().extend(new Env2()).extend(new Env3());
@@ -221,19 +221,19 @@ test('test.extend should chain worker and test args', async ({ runInlineTest }) 
   });
   expect(passed).toBe(1);
   expect(output).toContain([
-    'beforeAll1',
-    'beforeAll2-w1=w1',
-    'beforeAll3-w1=w1,w2=w2',
-    'beforeEach1',
-    'beforeEach2-t1=t1',
-    'beforeEach3-t1=t1,t2=t2',
+    'setupWorker1',
+    'setupWorker2-w1=w1',
+    'setupWorker3-w1=w1,w2=w2',
+    'setupTest1',
+    'setupTest2-t1=t1',
+    'setupTest3-t1=t1,t2=t2',
     'test-t1=t1,t2=t2,t3=t3',
-    'afterEach3-t1=t1,t2=t2,t3=t3',
-    'afterEach2-t1=t1,t2=t2',
-    'afterEach1-t1=t1',
-    'afterAll3-w1=w1,w2=w2,w3=w3',
-    'afterAll2-w1=w1,w2=w2',
-    'afterAll1-w1=w1',
+    'teardownTest3-t1=t1,t2=t2,t3=t3',
+    'teardownTest2-t1=t1,t2=t2',
+    'teardownTest1-t1=t1',
+    'teardownWorker3-w1=w1,w2=w2,w3=w3',
+    'teardownWorker2-w1=w1,w2=w2',
+    'teardownWorker1-w1=w1',
   ].join('\n'));
 });
 
@@ -241,12 +241,12 @@ test('env.options should work', async ({ runInlineTest }) => {
   const { exitCode, passed } = await runInlineTest({
     'folio.config.ts': `
       export class Env1 {
-        async beforeAll(options) {
+        async setupWorker(options) {
           return { bar: options.foo + '2' };
         }
       }
       export class Env2 {
-        async beforeAll(options) {
+        async setupWorker(options) {
           return { baz: options.foo + options.bar };
         }
       }

--- a/test/test-info.spec.ts
+++ b/test/test-info.spec.ts
@@ -34,7 +34,7 @@ test('should work via env', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'folio.config.ts': `
       class MyEnv {
-        async beforeEach(args, testInfo) {
+        async setupTest(args, testInfo) {
           return { title: testInfo.title };
         }
       }

--- a/test/test-output-dir.spec.ts
+++ b/test/test-output-dir.spec.ts
@@ -52,7 +52,7 @@ test('should include runWith tag', async ({ runInlineTest }) => {
         constructor(snapshotPathSegment) {
           this._snapshotPathSegment = snapshotPathSegment;
         }
-        async beforeEach(args, testInfo) {
+        async setupTest(args, testInfo) {
           testInfo.snapshotPathSegment = this._snapshotPathSegment;
           return {};
         }

--- a/test/timeout.spec.ts
+++ b/test/timeout.spec.ts
@@ -16,11 +16,11 @@
 
 import { test, expect } from './config';
 
-test('should run env afterEach on timeout', async ({ runInlineTest }) => {
+test('should run teardownTest on timeout', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'folio.config.ts': `
       class MyEnv {
-        async afterEach({}, testInfo) {
+        async teardownTest({}, testInfo) {
           console.log('STATUS:' + testInfo.status);
         }
       }

--- a/test/types-2.spec.ts
+++ b/test/types-2.spec.ts
@@ -62,7 +62,7 @@ test('test.declare should check types', async ({runTSC}) => {
     'folio.config.ts': `
       export const test = folio.test;
       export const test1 = test.declare<{ foo: string }>();
-      export const test2 = test1.extend({ beforeEach: ({ foo }) => { return { bar: parseInt(foo) }; } });
+      export const test2 = test1.extend({ setupTest: ({ foo }) => { return { bar: parseInt(foo) }; } });
       test.runWith({});
       test1.runWith({});
       test2.runWith({});

--- a/test/types.spec.ts
+++ b/test/types.spec.ts
@@ -30,20 +30,20 @@ test('runWith should check types of options', async ({runTSC}) => {
   const result = await runTSC({
     'folio.config.ts': `
       export const test = folio.test.extend({
-        optionsType(): { foo: string, bar: number } {
+        workerOptionsType(): { foo: string, bar: number } {
           return {} as any;
         },
-        async beforeEach({}, testInfo: folio.TestInfo) {
+        async setupTest({}, testInfo: folio.TestInfo) {
           return { a: '42', b: 42 };
         }
       });
       class Env1 {
-        beforeAll() {
+        setupWorker() {
           return { foo: '42', bar: 42 };
         }
       }
       class Env2 {
-        beforeAll() {
+        setupWorker() {
           return { foo: '42' };
         }
       }
@@ -65,7 +65,7 @@ test('runWith should check types of options', async ({runTSC}) => {
       // @ts-expect-error
       test.runWith({ options: { foo: 42, bar: 42 } });
       // @ts-expect-error
-      test.runWith({ beforeAll: async () => { return {}; } });
+      test.runWith({ setupWorker: async () => { return {}; } });
       // @ts-expect-error
       test.runWith(new Env2(), { timeout: 100 });
       // TODO: next line should not compile.
@@ -92,8 +92,8 @@ test('runWith should allow void env', async ({runTSC}) => {
       test.runWith({});
       test.runWith({ timeout: 100 });
       test.runWith({ timeout: 100 });
-      test.runWith({ beforeEach: () => {} });
-      test.runWith({ beforeEach: () => { return 42; } });
+      test.runWith({ setupTest: () => {} });
+      test.runWith({ setupTest: () => { return 42; } });
     `,
     'a.spec.ts': `
       import { test } from './folio.config';
@@ -109,17 +109,17 @@ test('test.extend should check types', async ({runTSC}) => {
     'folio.config.ts': `
       export const test = folio.test.declare<{ foo: string }>();
       class FooEnv {
-        beforeEach() {
+        setupTest() {
           return { foo: '17' };
         }
       }
-      export const test1 = test.extend({ beforeEach: ({ foo }) => { return { bar: parseInt(foo) + 42 }; } });
+      export const test1 = test.extend({ setupTest: ({ foo }) => { return { bar: parseInt(foo) + 42 }; } });
       test.runWith(new FooEnv());
       test1.runWith(new FooEnv());
-      export const test2 = test1.extend({ beforeEach: ({ bar }) => { return { baz: bar - 5 }; } });
+      export const test2 = test1.extend({ setupTest: ({ bar }) => { return { baz: bar - 5 }; } });
       test2.runWith(new FooEnv());
       // @ts-expect-error
-      export const test3 = test.extend({ beforeEach: ({ bar }) => { return { baz: bar - 5 }; } });
+      export const test3 = test.extend({ setupTest: ({ bar }) => { return { baz: bar - 5 }; } });
     `,
     'a.spec.ts': `
       import { test, test1, test2 } from './folio.config';


### PR DESCRIPTION
- `beforeAll` -> `setupWorker`;
- `afterAll` -> `teardownWorker`;
- `beforeEach` -> `setupTest`;
- `afterEach` -> `teardownTest`;
- `optionsType` -> `workerOptionsType`.