### PR TITLE
feat: reuse worker process between test types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -26,7 +26,7 @@ import ListReporter from './reporters/list';
 export * from './types';
 export { expect } from './expect';
 export { setConfig, setReporters, globalSetup, globalTeardown } from './spec';
-export const test: TestType<{}, {}, {}, {}> = newTestTypeImpl([]);
+export const test: TestType<{}, {}, {}, {}> = newTestTypeImpl([], undefined);
 export const reporters = {
   dot: DotReporter,
   json: JSONReporter,

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -57,12 +57,10 @@ export class Runner {
     const grepMatcher = createMatcher(this._loader.config().grep);
 
     const nonEmptySuites = new Set<Suite>();
-    let descriptionIndex = 0;
     for (const runList of this._loader.runLists()) {
       if (tagFilter && !runList.tags.some(tag => tagFilter.includes(tag)))
         continue;
       for (const description of this._loader.descriptionsForRunList(runList)) {
-        ++descriptionIndex;
         for (const fileSuite of description.fileSuites.values()) {
           if (filtered.size && !filtered.has(fileSuite))
             continue;
@@ -78,7 +76,7 @@ export class Runner {
                 outputDir: config.outputDir,
                 repeatEachIndex: i,
                 runListIndex: runList.index,
-                workerHash: `${descriptionIndex}#repeat-${i}`,
+                workerHash: `#list-${runList.index}#env-${description.envHash}#repeat-${i}`,
                 variationId: `#run-${runList.index}#repeat-${i}`,
               };
               spec._appendTest(testVariation);

--- a/src/spec.ts
+++ b/src/spec.ts
@@ -32,6 +32,7 @@ export type TestTypeDescription = {
   fileSuites: Map<string, Suite>;
   children: Set<AnyTestType>;
   envs: Env<any>[];
+  newEnv: Env<any> | undefined;
 };
 export type RunListDescription = {
   index: number;
@@ -63,12 +64,13 @@ export function setLoadingConfigFile(loading: boolean) {
 
 const countByFile = new Map<string, number>();
 
-export function newTestTypeImpl(envs: Env<any>[]): any {
+export function newTestTypeImpl(envs: Env<any>[], newEnv: Env<any> | undefined): any {
   const fileSuites = new Map<string, Suite>();
   const description: TestTypeDescription = {
     fileSuites,
     children: new Set(),
     envs,
+    newEnv,
   };
   let suites: Suite[] = [];
 
@@ -167,12 +169,12 @@ export function newTestTypeImpl(envs: Env<any>[]): any {
     suites[0]._testOptions = options;
   };
   test.extend = (env?: Env<any>) => {
-    const newTestType = newTestTypeImpl(env ? [...envs, env] : envs);
+    const newTestType = newTestTypeImpl(env ? [...envs, env] : envs, env);
     description.children.add(newTestType);
     return newTestType;
   };
   test.declare = () => {
-    const newTestType = newTestTypeImpl(envs);
+    const newTestType = newTestTypeImpl(envs, undefined);
     description.children.add(newTestType);
     return newTestType;
   };


### PR DESCRIPTION
When two test types only differ in the last few
environments, and none of them has `beforeAll` or `afterAll`,
we can reuse the worker. In this case, the worker won't have
to run new `beforeAll`/`afterAll` methods, and will update
the list of envs to run `beforeEach`/`afterEach` for the next test.