### PR TITLE
feat: allow useOptions for worker-level options

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@babel/code-frame": "^7.10.4",
     "@babel/core": "^7.11.4",
     "@babel/plugin-proposal-class-properties": "^7.10.4",
+    "@babel/plugin-proposal-private-property-in-object": "^7.14.0",
     "@babel/preset-env": "^7.11.0",
     "@babel/preset-typescript": "^7.10.4",
     "colors": "^1.4.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ import { errorWithCallLocation } from './util';
 
 export * from './types';
 export { expect } from './expect';
-export const test: TestType<{}, {}, {}, {}, {}, {}> = rootTestType.test;
+export const test: TestType<{}, {}, {}, {}, {}> = rootTestType.test;
 
 export function setConfig(config: Config) {
   const configFile = currentlyLoadingConfigFile();
@@ -45,8 +45,8 @@ export function globalTeardown(globalTeardownFunction: () => any) {
   configFile.globalTeardown(globalTeardownFunction);
 }
 
-type WorkerOptionsForEnv<T> = T extends TestType<infer T, infer W, infer TO, infer WO, infer DT, infer DW> ? WO : never;
-export function runTests<T = typeof test>(config?: RunListConfig<WorkerOptionsForEnv<T>>) {
+type OptionsForEnv<T> = T extends TestType<infer T, infer W, infer O, infer DT, infer DW> ? O : never;
+export function runTests<T = typeof test>(config?: RunListConfig<OptionsForEnv<T>>) {
   const configFile = currentlyLoadingConfigFile();
   if (!configFile)
     throw errorWithCallLocation(`runTests() can only be called in a configuration file.`);

--- a/src/test.ts
+++ b/src/test.ts
@@ -76,7 +76,7 @@ export class Spec extends Base implements types.Spec {
 export class Suite extends Base implements types.Suite {
   suites: Suite[] = [];
   specs: Spec[] = [];
-  _testOptions: any;
+  _options: any;
   _entries: (Suite | Spec)[] = [];
   _hooks: { type: string, fn: Function } [] = [];
 
@@ -106,27 +106,29 @@ export class Suite extends Base implements types.Suite {
   }
 
   findTest(fn: (test: Test) => boolean | void): boolean {
-    for (const suite of this.suites) {
-      if (suite.findTest(fn))
-        return true;
-    }
-    for (const spec of this.specs) {
-      for (const test of spec.tests) {
-        if (fn(test))
+    for (const entry of this._entries) {
+      if (entry instanceof Suite) {
+        if (entry.findTest(fn))
           return true;
+      } else {
+        for (const test of entry.tests) {
+          if (fn(test))
+            return true;
+        }
       }
     }
     return false;
   }
 
   findSpec(fn: (spec: Spec) => boolean | void): boolean {
-    for (const suite of this.suites) {
-      if (suite.findSpec(fn))
-        return true;
-    }
-    for (const spec of this.specs) {
-      if (fn(spec))
-        return true;
+    for (const entry of this._entries) {
+      if (entry instanceof Suite) {
+        if (entry.findSpec(fn))
+          return true;
+      } else {
+        if (fn(entry))
+          return true;
+      }
     }
     return false;
   }

--- a/src/testType.ts
+++ b/src/testType.ts
@@ -27,7 +27,7 @@ const countByFile = new Map<string, number>();
 export class TestTypeImpl {
   readonly children = new Set<TestTypeImpl>();
   readonly envs: (Env | DeclaredEnv)[];
-  readonly test: TestType<any, any, any, any, any, any>;
+  readonly test: TestType<any, any, any, any, any>;
 
   constructor(envs: (Env | DeclaredEnv)[]) {
     this.envs = envs;
@@ -121,7 +121,7 @@ export class TestTypeImpl {
     const suite = currentlyLoadingFileSuite();
     if (!suite)
       throw errorWithCallLocation(`useOptions() can only be called in a test file.`);
-    suite._testOptions = options;
+    suite._options = options;
   }
 
   private _extend(env?: Env) {
@@ -169,7 +169,7 @@ export type RunListConfig<WorkerOptions = {}> = {
 export class RunList {
   index = 0;
   tags: string[];
-  workerOptions: any;
+  options: any;
   config: {
     outputDir?: string;
     repeatEach?: number;
@@ -182,7 +182,7 @@ export class RunList {
   constructor(config: RunListConfig) {
     const tag = 'tag' in config ? config.tag : [];
     this.tags = Array.isArray(tag) ? tag : [tag];
-    this.workerOptions = config.options;
+    this.options = config.options;
     this.config = {
       timeout: config.timeout,
       repeatEach: config.repeatEach,

--- a/src/types.ts
+++ b/src/types.ts
@@ -123,7 +123,7 @@ interface TestFunction<TestArgs> {
   (name: string, inner: (args: TestArgs, testInfo: TestInfo) => Promise<void> | void): void;
 }
 
-export interface TestType<TestArgs, WorkerArgs, TestOptions, WorkerOptions, DeclaredTestArgs, DeclaredWorkerArgs> extends TestFunction<TestArgs>, TestModifier<TestArgs> {
+export interface TestType<TestArgs, WorkerArgs, Options, DeclaredTestArgs, DeclaredWorkerArgs> extends TestFunction<TestArgs>, TestModifier<TestArgs> {
   only: TestFunction<TestArgs>;
   describe: SuiteFunction & {
     only: SuiteFunction;
@@ -133,15 +133,15 @@ export interface TestType<TestArgs, WorkerArgs, TestOptions, WorkerOptions, Decl
   afterEach(inner: (args: TestArgs, testInfo: TestInfo) => Promise<any> | any): void;
   beforeAll(inner: (args: WorkerArgs, workerInfo: WorkerInfo) => Promise<any> | any): void;
   afterAll(inner: (args: WorkerArgs, workerInfo: WorkerInfo) => Promise<any> | any): void;
-  useOptions(options: TestOptions): void;
+  useOptions(options: Options): void;
 
   expect: Expect;
 
-  extend(): TestType<TestArgs, WorkerArgs, TestOptions, WorkerOptions, DeclaredTestArgs, DeclaredWorkerArgs>;
-  extend<T, W, TO, WO>(env: Env<T, W, TO, WO, TestArgs & TestOptions, WorkerArgs & WorkerOptions>): TestType<TestArgs & T & W, WorkerArgs & W, TestOptions & TO, WorkerOptions & WO, DeclaredTestArgs, DeclaredWorkerArgs>;
-  declare<T = {}, W = {}, TO = {}, WO = {}>(): {
-    test: TestType<TestArgs & T & W, WorkerArgs & W, TestOptions, WorkerOptions, T, W>;
-    define(env: Env<T, W, TO, WO, TestArgs & TestOptions, WorkerArgs & WorkerOptions>): DefinedEnv;
+  extend(): TestType<TestArgs, WorkerArgs, Options, DeclaredTestArgs, DeclaredWorkerArgs>;
+  extend<T, W, O>(env: Env<T, W, O, TestArgs & Options, WorkerArgs & Options>): TestType<TestArgs & T & W, WorkerArgs & W, Options & O, DeclaredTestArgs, DeclaredWorkerArgs>;
+  declare<T = {}, W = {}, O = {}>(): {
+    test: TestType<TestArgs & T & W, WorkerArgs & W, Options, T, W>;
+    define(env: Env<T, W, O, TestArgs & Options, WorkerArgs & Options>): DefinedEnv;
   };
 }
 
@@ -154,16 +154,12 @@ type MaybePromise<T> = T | Promise<T>;
 type MaybeVoidIf<T, R> = {} extends T ? R | void : R;
 type MaybeVoid<T> = MaybeVoidIf<T, T>;
 
-export interface Env<TestArgs = {}, WorkerArgs = {}, TestOptions = {}, WorkerOptions = {}, PreviousTestArgs = {}, PreviousWorkerArgs = {}> {
-  // For type inference.
-  testOptionsType?(): TestOptions;
-  optionsType?(): WorkerOptions;
-
-  // Implementation.
-  beforeEach?(args: PreviousTestArgs & TestOptions, testInfo: TestInfo): MaybePromise<MaybeVoid<TestArgs>>;
-  beforeAll?(args: PreviousWorkerArgs & WorkerOptions, workerInfo: WorkerInfo): MaybePromise<MaybeVoid<WorkerArgs>>;
-  afterEach?(args: PreviousTestArgs & TestOptions, testInfo: TestInfo): MaybePromise<any>;
-  afterAll?(args: PreviousWorkerArgs & WorkerOptions, workerInfo: WorkerInfo): MaybePromise<any>;
+export interface Env<TestArgs = {}, WorkerArgs = {}, Options = {}, PreviousTestArgs = {}, PreviousWorkerArgs = {}> {
+  hasBeforeAllOptions?(options: Options): boolean;
+  beforeEach?(args: PreviousTestArgs & Options, testInfo: TestInfo): MaybePromise<MaybeVoid<TestArgs>>;
+  beforeAll?(args: PreviousWorkerArgs & Options, workerInfo: WorkerInfo): MaybePromise<MaybeVoid<WorkerArgs>>;
+  afterEach?(args: PreviousTestArgs & Options, testInfo: TestInfo): MaybePromise<any>;
+  afterAll?(args: PreviousWorkerArgs & Options, workerInfo: WorkerInfo): MaybePromise<any>;
 }
 
 // ---------- Reporters API -----------

--- a/test/options.spec.ts
+++ b/test/options.spec.ts
@@ -16,7 +16,7 @@
 
 import { test, expect } from './config';
 
-test('should run tests with different options', async ({ runInlineTest }) => {
+test('should run tests with different test options in the same worker', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'folio.config.ts': `
       global.logs = [];
@@ -30,25 +30,75 @@ test('should run tests with different options', async ({ runInlineTest }) => {
     `,
     'a.test.ts': `
       import { test } from './folio.config';
-      test('test', ({ foo }) => {
+      test('test', ({ foo }, testInfo) => {
         expect(foo).toBe('foo');
+        expect(testInfo.workerIndex).toBe(0);
       });
 
       test.describe('suite1', () => {
         test.useOptions({ foo: 'bar' });
-        test('test1', ({ foo }) => {
+        test('test1', ({ foo }, testInfo) => {
           expect(foo).toBe('bar');
+          expect(testInfo.workerIndex).toBe(0);
         });
 
         test.describe('suite2', () => {
           test.useOptions({ foo: 'baz' });
-          test('test2', ({ foo }) => {
+          test('test2', ({ foo }, testInfo) => {
             expect(foo).toBe('baz');
+            expect(testInfo.workerIndex).toBe(0);
           });
         });
       });
     `
-  });
+  }, { workers: 1 });
   expect(result.exitCode).toBe(0);
   expect(result.passed).toBe(3);
+});
+
+test('should run tests with different worker options', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'folio.config.ts': `
+      class MyEnv {
+        hasBeforeAllOptions(options) {
+          return 'foo' in options;
+        }
+        async beforeAll(options) {
+          return { foo: options.foo };
+        }
+      }
+      export const test = folio.test.extend(new MyEnv());
+      folio.runTests();
+    `,
+    'a.test.ts': `
+      import { test } from './folio.config';
+      test('test', ({ foo }, testInfo) => {
+        expect(foo).toBe(undefined);
+        expect(testInfo.workerIndex).toBe(0);
+      });
+
+      test.describe('suite1', () => {
+        test.useOptions({ foo: 'bar' });
+        test('test1', ({ foo }, testInfo) => {
+          expect(foo).toBe('bar');
+          expect(testInfo.workerIndex).toBe(1);
+        });
+
+        test.describe('suite2', () => {
+          test.useOptions({ foo: 'baz' });
+          test('test2', ({ foo }, testInfo) => {
+            expect(foo).toBe('baz');
+            expect(testInfo.workerIndex).toBe(2);
+          });
+        });
+
+        test('test3', ({ foo }, testInfo) => {
+          expect(foo).toBe('bar');
+          expect(testInfo.workerIndex).toBe(1);
+        });
+      });
+    `
+  }, { workers: 1 });
+  expect(result.exitCode).toBe(0);
+  expect(result.passed).toBe(4);
 });

--- a/test/types.spec.ts
+++ b/test/types.spec.ts
@@ -30,8 +30,8 @@ test('runTests should check types of options', async ({runTSC}) => {
   const result = await runTSC({
     'folio.config.ts': `
       export const test = folio.test.extend({
-        optionsType(): { foo: string, bar: number } {
-          return {} as any;
+        hasBeforeAllOptions(options: { foo: string, bar: number }) {
+          return false;
         },
         async beforeEach({}, testInfo: folio.TestInfo) {
           return { a: '42', b: 42 };


### PR DESCRIPTION
Achieved by replacing `optionsType()` and `testOptionsType()` with `hasBeforeAllOptions()`.