### PR TITLE
fix(babel): setPublicClassFields: true and remove private vars

### DIFF
--- a/src/transform.ts
+++ b/src/transform.ts
@@ -62,12 +62,16 @@ export function installTransform(): () => void {
     const result = babel.transformFileSync(filename, {
       babelrc: false,
       configFile: false,
+      assumptions: {
+        // Without this, babel defines a top level function that
+        // breaks playwright evaluates.
+        setPublicClassFields: true,
+      },
       presets: [
         ['@babel/preset-typescript', { onlyRemoveTypeImports: true }],
       ],
       plugins: [
         ['@babel/plugin-proposal-class-properties'],
-        ['@babel/plugin-proposal-private-methods'],
         ['@babel/plugin-proposal-numeric-separator'],
         ['@babel/plugin-proposal-logical-assignment-operators'],
         ['@babel/plugin-proposal-nullish-coalescing-operator'],
@@ -81,7 +85,7 @@ export function installTransform(): () => void {
         ['@babel/plugin-proposal-dynamic-import'],
       ],
       sourceMaps: 'both',
-    });
+    } as babel.TransformOptions);
     if (result.code) {
       fs.mkdirSync(path.dirname(cachePath), {recursive: true});
       if (result.map)


### PR DESCRIPTION
setPublicClassFields: true simplifies how babel transforms class properties.
Without it, babel imports a top level function to define the properties.
This isn't in scope for playwright evaluates, which causes them to throw errors.﻿

I also removed the private variables plugin for the same reason.
