### PR TITLE
docs: add license to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -848,3 +848,7 @@ To import expect matching libraries like [jest-extended](https://github.com/jest
 ```ts
 import 'jest-extended';
 ```
+
+# LICENSE
+
+Folio is licensed under the Apache License, Version 2.0. See [LICENSE](LICENSE) for the full license text.


### PR DESCRIPTION
I think it's important to show the license of software is being distributed at `README.md`.

What do you think?