### PR TITLE
fix: snapshotDir with multiple projects

### DIFF
--- a/src/project.ts
+++ b/src/project.ts
@@ -30,14 +30,16 @@ type TestTypeData = {
 
 export class ProjectImpl {
   config: FullProject;
+  readonly useRootDirForSnapshots: boolean;
   private index: number;
   private defines = new Map<TestType<any, any, any>, Env>();
   private testTypeToData = new Map<TestTypeImpl, TestTypeData>();
   private lastForkingAncestorHash = 0;
 
-  constructor(project: FullProject, index: number) {
+  constructor(project: FullProject, index: number, useRootDirForSnapshots: boolean) {
     this.config = project;
     this.index = index;
+    this.useRootDirForSnapshots = useRootDirForSnapshots;
     this.defines = new Map();
     for (const { test, env } of Array.isArray(project.define) ? project.define : [project.define])
       this.defines.set(test, env);

--- a/src/workerRunner.ts
+++ b/src/workerRunner.ts
@@ -210,6 +210,7 @@ export class WorkerRunner extends EventEmitter {
     const testId = test._id;
 
     const relativeTestFilePath = path.relative(this._project.config.testDir, spec.file.replace(/\.(spec|test)\.(js|ts)/, ''));
+    const relativeTestFilePathForSnapshots = path.relative(this._project.useRootDirForSnapshots ? this._loader.fullConfig().rootDir : this._project.config.testDir, spec.file.replace(/\.(spec|test)\.(js|ts)/, ''));
     const sanitizedTitle = spec.title.replace(/[^\w\d]+/g, '-');
     const baseOutputDir = (() => {
       const sanitizedRelativePath = relativeTestFilePath.replace(process.platform === 'win32' ? new RegExp('\\\\', 'g') : new RegExp('/', 'g'), '-');
@@ -245,7 +246,7 @@ export class WorkerRunner extends EventEmitter {
         return path.join(baseOutputDir, ...pathSegments);
       },
       snapshotPath: (...pathSegments: string[]): string => {
-        const basePath = path.join(this._project.config.testDir, this._project.config.snapshotDir, relativeTestFilePath, sanitizedTitle, testInfo.snapshotPathSegment);
+        const basePath = path.join(this._project.config.snapshotDir, relativeTestFilePathForSnapshots, sanitizedTitle, testInfo.snapshotPathSegment);
         return path.join(basePath, ...pathSegments);
       },
       skip: (arg?: boolean | string | Function, description?: string) => modifier(testInfo, 'skip', arg, description),


### PR DESCRIPTION
- If nothing is specified, each project gets the default `<testDir>/__snapshots__`.
- Each project can specify its own `snapshotDir`, absolute or relative.
- If root config has `snapshotDir` specified, it will be used for all projects that do not specify their own.