### PR TITLE
feat: allow specifiyng project metadata that is reported in json

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -32,6 +32,7 @@ const defaultConfig: FullConfig = {
   grep: /.*/,
   maxFailures: 0,
   preserveOutput: process.env.CI ? 'failures-only' : 'always',
+  projects: [],
   reporter: [process.env.CI ? 'dot' : 'list'],
   rootDir: path.resolve(process.cwd()),
   quiet: false,

--- a/src/dispatcher.ts
+++ b/src/dispatcher.ts
@@ -242,7 +242,6 @@ export class Dispatcher {
     });
     worker.on('testEnd', (params: TestEndPayload) => {
       const { test, result } = this._testById.get(params.testId);
-      result.data = params.data;
       result.duration = params.duration;
       result.error = params.error;
       test.expectedStatus = params.expectedStatus;

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -40,9 +40,8 @@ export type TestEndPayload = {
   duration: number;
   status: TestStatus;
   error?: TestError;
-  data: any;
   expectedStatus: TestStatus;
-  annotations: any[];
+  annotations: { type: string, description?: string }[];
   timeout: number;
 };
 

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -107,6 +107,7 @@ export class Loader {
 
     for (const project of projects)
       this._addProject(project, this._fullConfig.rootDir);
+    this._fullConfig.projects = this._projects.map(p => p.config);
   }
 
   loadTestFile(file: string) {
@@ -187,6 +188,7 @@ export class Loader {
       repeatEach: takeFirst(this._configOverrides.repeatEach, projectConfig.repeatEach, this._config.repeatEach, 1),
       retries: takeFirst(this._configOverrides.retries, projectConfig.retries, this._config.retries, 0),
       snapshotDir,
+      metadata: projectConfig.metadata,
       name: projectConfig.name || '',
       testDir,
       testIgnore: projectConfig.testIgnore || 'node_modules/**',

--- a/src/test.ts
+++ b/src/test.ts
@@ -207,7 +207,6 @@ export class Test implements types.Test {
       duration: 0,
       stdout: [],
       stderr: [],
-      data: {}
     };
     this.results.push(result);
     return result;

--- a/src/types.ts
+++ b/src/types.ts
@@ -56,6 +56,11 @@ interface ProjectBase {
   snapshotDir?: string;
 
   /**
+   * Any JSON-serializable metadata that will be put directly to the test report.
+   */
+  metadata?: any;
+
+  /**
    * The project name, shown in the title of each test.
    */
   name?: string;
@@ -188,6 +193,7 @@ export interface FullConfig {
   grep: RegExp | RegExp[];
   maxFailures: number;
   preserveOutput: PreserveOutput;
+  projects: FullProject[];
   reporter: ReporterDescription[];
   rootDir: string;
   quiet: boolean;
@@ -350,11 +356,6 @@ export interface TestInfo extends WorkerInfo {
    * Only available after the test has finished.
    */
   stderr: (string | Buffer)[];
-
-  /**
-   * JSON-serializable data that is put here will appear in the test report.
-   */
-  data: { [key: string]: any };
 
   /**
    * Relative path segment used to differentiate snapshots between multiple test configurations.
@@ -928,7 +929,6 @@ export interface TestResult {
   error?: TestError;
   stdout: (string | Buffer)[];
   stderr: (string | Buffer)[];
-  data: { [key: string]: any };
 }
 export interface TestError {
   message?: string;

--- a/src/workerRunner.ts
+++ b/src/workerRunner.ts
@@ -210,7 +210,6 @@ export class WorkerRunner extends EventEmitter {
       stdout: [],
       stderr: [],
       timeout: this._project.config.timeout,
-      data: {},
       snapshotPathSegment: '',
       outputDir: baseOutputDir,
       outputPath: (...pathSegments: string[]): string => {
@@ -407,7 +406,6 @@ function buildTestEndPayload(testId: string, testInfo: TestInfo): TestEndPayload
     duration: testInfo.duration,
     status: testInfo.status!,
     error: testInfo.error,
-    data: testInfo.data,
     expectedStatus: testInfo.expectedStatus,
     annotations: testInfo.annotations,
     timeout: testInfo.timeout,

--- a/test/access-data.spec.ts
+++ b/test/access-data.spec.ts
@@ -37,16 +37,18 @@ test('should access error in fixture', async ({ runInlineTest }) => {
   expect(data.message).toContain('Object.is equality');
 });
 
-test('should access data in fixture', async ({ runInlineTest }) => {
+test('should access annotations in fixture', async ({ runInlineTest }) => {
   const { exitCode, report } = await runInlineTest({
     'test-data-visible-in-env.spec.ts': `
       const test = folio.test.extend({
         foo: [async ({}, run, testInfo) => {
           await run();
-          testInfo.data['myname'] = 'myvalue';
+          testInfo.annotations.push({ type: 'myname', description: 'hello' });
         }, { auto: true }],
       });
       test('ensure env can set data', async ({}, testInfo) => {
+        test.slow(true, 'just slow');
+
         console.log('console.log');
         console.error('console.error');
         expect(testInfo.config.rootDir).toBeTruthy();
@@ -55,10 +57,10 @@ test('should access data in fixture', async ({ runInlineTest }) => {
     `
   });
   expect(exitCode).toBe(0);
-  const testResult = report.suites[0].specs[0].tests[0].results[0];
-  expect(testResult.data).toEqual({ 'myname': 'myvalue' });
-  expect(testResult.stdout).toEqual([{ text: 'console.log\n' }]);
-  expect(testResult.stderr).toEqual([{ text: 'console.error\n' }]);
+  const test = report.suites[0].specs[0].tests[0];
+  expect(test.annotations).toEqual([ { type: 'slow', description: 'just slow' }, { type: 'myname', description: 'hello' } ]);
+  expect(test.results[0].stdout).toEqual([{ text: 'console.log\n' }]);
+  expect(test.results[0].stderr).toEqual([{ text: 'console.error\n' }]);
 });
 
 test('should report projectName in result', async ({ runInlineTest }) => {

--- a/test/json-reporter.spec.ts
+++ b/test/json-reporter.spec.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import * as path from 'path';
 import { test, expect } from './folio-test';
 
 test('should support spec.ok', async ({ runInlineTest }) => {
@@ -31,4 +32,50 @@ test('should support spec.ok', async ({ runInlineTest }) => {
   expect(result.exitCode).toBe(1);
   expect(result.report.suites[0].specs[0].ok).toBe(true);
   expect(result.report.suites[0].specs[1].ok).toBe(false);
+});
+
+test('should report projects', async ({ runInlineTest }, testInfo) => {
+  const result = await runInlineTest({
+    'folio.config.ts': `
+      module.exports = {
+        retries: 2,
+        projects: [
+          {
+            timeout: 5000,
+            name: 'p1',
+            metadata: { foo: 'bar' },
+          },
+          {
+            timeout: 8000,
+            name: 'p2',
+            metadata: { bar: 42 },
+          }
+        ]
+      };
+    `,
+    'a.test.js': `
+      const { test } = folio;
+      test('math works!', async ({}) => {
+        expect(1 + 1).toBe(2);
+      });
+    `
+  }, { });
+  expect(result.exitCode).toBe(0);
+  const projects = result.report.config.projects;
+  const testDir = testInfo.outputDir.split(path.sep).join(path.posix.sep);
+
+  expect(projects[0].name).toBe('p1');
+  expect(projects[0].retries).toBe(2);
+  expect(projects[0].timeout).toBe(5000);
+  expect(projects[0].metadata).toEqual({ foo: 'bar' });
+  expect(projects[0].testDir).toBe(testDir);
+
+  expect(projects[1].name).toBe('p2');
+  expect(projects[1].retries).toBe(2);
+  expect(projects[1].timeout).toBe(8000);
+  expect(projects[1].metadata).toEqual({ bar: 42 });
+  expect(projects[1].testDir).toBe(testDir);
+
+  expect(result.report.suites[0].specs[0].tests[0].projectName).toBe('p1');
+  expect(result.report.suites[0].specs[0].tests[1].projectName).toBe('p2');
 });

--- a/test/types-2.spec.ts
+++ b/test/types-2.spec.ts
@@ -24,7 +24,6 @@ test('basics should work', async ({runTSC}) => {
         test.beforeEach(async () => {});
         test('my test', async({}, testInfo) => {
           expect(testInfo.title).toBe('my test');
-          testInfo.data.foo = 'bar';
           testInfo.annotations[0].type;
         });
       });


### PR DESCRIPTION
Also remove `testInfo.data`, use `testInfo.annotations` when needed.