### PR TITLE
fix(testmatch): match absolute path, treat args as regex

### DIFF
--- a/src/loader.ts
+++ b/src/loader.ts
@@ -191,7 +191,7 @@ export class Loader {
       metadata: projectConfig.metadata,
       name: projectConfig.name || '',
       testDir,
-      testIgnore: projectConfig.testIgnore || 'node_modules/**',
+      testIgnore: projectConfig.testIgnore || '**/node_modules/**',
       testMatch: projectConfig.testMatch || '**/?(*.)+(spec|test).[jt]s',
       timeout: takeFirst(this._configOverrides.timeout, projectConfig.timeout, this._config.timeout, 10000),
       use: projectConfig.use || {},

--- a/src/types.ts
+++ b/src/types.ts
@@ -72,11 +72,15 @@ interface ProjectBase {
 
   /**
    * Files matching one of these patterns are not considered test files.
+   * Matching is performed against the absolute file path.
+   * Strings are treated as glob patterns.
    */
   testIgnore?: string | RegExp | (string | RegExp)[];
 
   /**
    * Only files matching one of these patterns are considered test files.
+   * Matching is performed against the absolute file path.
+   * Strings are treated as glob patterns.
    */
   testMatch?: string | RegExp | (string | RegExp)[];
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -130,14 +130,16 @@ export function prependErrorMessage(e: Error, message: string) {
   e.stack = e.message + stack;
 }
 
-export function createMatcher(patterns: string | RegExp | (string | RegExp)[]): (value: string) => boolean {
+export type Matcher = (value: string) => boolean;
+
+export function createMatcher(patterns: string | RegExp | (string | RegExp)[]): Matcher {
   const reList: RegExp[] = [];
   const filePatterns: string[] = [];
   for (const pattern of Array.isArray(patterns) ? patterns : [patterns]) {
     if (pattern instanceof RegExp || Object.prototype.toString.call(pattern) === '[object RegExp]') {
       reList.push(pattern as RegExp);
     } else {
-      if (!pattern.includes('/') && !pattern.includes('\\'))
+      if (!pattern.startsWith('**/') && !pattern.startsWith('**/'))
         filePatterns.push('**/' + pattern);
       else
         filePatterns.push(pattern);


### PR DESCRIPTION
This changes from relative path match to absolute path match,
to support quite common `npx folio test/foo.spec`, where
test root directory is `test`.

Also treat args as regular expressions.

Fixes #275.