### PR TITLE
fix(reporters): print errors without message correctly

### DIFF
--- a/src/reporters/base.ts
+++ b/src/reporters/base.ts
@@ -200,11 +200,11 @@ function formatError(error: TestError, file?: string) {
       tokens.push(codeFrameColumns(source, {
         start: position,
       },
-      { highlightCode: true}
+      { highlightCode: colors.enabled }
       ));
     }
     tokens.push('');
-    tokens.push(colors.dim(stack.substring(preamble.length + 1)));
+    tokens.push(colors.dim(preamble.length > 0 ? stack.substring(preamble.length + 1) : stack));
   } else {
     tokens.push('');
     tokens.push(error.value);


### PR DESCRIPTION
The second test case was failing before and resulted in `rror: ` instead of `Error: `.