### PR TITLE
fix: misc fixes after dogfooding

### DIFF
--- a/src/fixtures.ts
+++ b/src/fixtures.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { errorWithCallLocation, formatLocation, prependErrorMessage } from './util';
+import { errorWithCallLocation, formatLocation, prependErrorMessage, wrapInPromise } from './util';
 import * as crypto from 'crypto';
 import { FixturesWithLocation, Location } from './types';
 
@@ -69,14 +69,14 @@ class Fixture {
     let called = false;
     const setupFence = new Promise<void>((f, r) => { setupFenceFulfill = f; setupFenceReject = r; });
     const teardownFence = new Promise(f => this._teardownFenceCallback = f);
-    this._tearDownComplete = this.registration.fn(params, async (value: any) => {
+    this._tearDownComplete = wrapInPromise(this.registration.fn(params, async (value: any) => {
       if (called)
         throw errorWithCallLocation(`Cannot provide fixture value for the second time`);
       called = true;
       this.value = value;
       setupFenceFulfill();
       return await teardownFence;
-    }, info).catch((e: any) => {
+    }, info)).catch((e: any) => {
       if (!this._setup)
         setupFenceReject(e);
       else

--- a/src/golden.ts
+++ b/src/golden.ts
@@ -85,10 +85,12 @@ export function compare(actual: Buffer | string, name: string, snapshotPath: (na
       fs.mkdirSync(path.dirname(snapshotFile), { recursive: true });
       fs.writeFileSync(snapshotFile, actual);
     }
-    return {
-      pass: false,
-      message: snapshotFile + ' is missing in golden results' + (writingActual ? ', writing actual.' : '.')
-    };
+    const message = snapshotFile + ' is missing in snapshots' + (writingActual ? ', writing actual.' : '.');
+    if (updateSnapshots === 'all') {
+      console.log(message);
+      return { pass: true, message };
+    }
+    return { pass: false, message };
   }
   const expected = fs.readFileSync(snapshotFile);
   const extension = path.extname(snapshotFile).substring(1);
@@ -108,10 +110,10 @@ export function compare(actual: Buffer | string, name: string, snapshotPath: (na
   if (updateSnapshots === 'all') {
     fs.mkdirSync(path.dirname(snapshotFile), { recursive: true });
     fs.writeFileSync(snapshotFile, actual);
-    console.log('Updating snapshot at ' + snapshotFile);
+    console.log(snapshotFile + ' does not match, writing actual.');
     return {
       pass: true,
-      message: snapshotFile + ' running with --p-update-snapshots, writing actual.'
+      message: snapshotFile + ' running with --update-snapshots, writing actual.'
     };
   }
   const outputFile = outputPath(name);

--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -24,7 +24,6 @@ export interface Suite {
   column: number;
   suites: Suite[];
   specs: Spec[];
-  fullTitle(): string;
   findTest(fn: (test: Test) => boolean | void): boolean;
   findSpec(fn: (spec: Spec) => boolean | void): boolean;
   totalTestCount(): number;
@@ -48,6 +47,7 @@ export interface Test {
   annotations: { type: string, description?: string }[];
   projectName: string;
   retries: number;
+  fullTitle(): string;
   status(): 'skipped' | 'expected' | 'unexpected' | 'flaky';
   ok(): boolean;
 }

--- a/src/reporters/base.ts
+++ b/src/reporters/base.ts
@@ -161,8 +161,7 @@ export function formatTestTitle(config: FullConfig, test: Test): string {
   const spec = test.spec;
   let relativePath = path.relative(config.rootDir, spec.file) || path.basename(spec.file);
   relativePath += ':' + spec.line + ':' + spec.column;
-  const projectName = test.projectName ? `[${test.projectName}] ` : '';
-  return `${relativePath} › ${projectName}${spec.fullTitle()}`;
+  return `${relativePath} › ${test.fullTitle()}`;
 }
 
 function formatTestHeader(config: FullConfig, test: Test, indent: string, index?: number): string {

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -92,7 +92,7 @@ export class Runner {
     const config = this._loader.fullConfig();
 
     const projects = this._loader.projects().filter(project => {
-      return !projectName || project.config.name === projectName;
+      return !projectName || project.config.name.toLocaleLowerCase() === projectName.toLocaleLowerCase();
     });
     if (projectName && !projects.length) {
       const names = this._loader.projects().map(p => p.config.name).filter(name => !!name);
@@ -142,7 +142,7 @@ export class Runner {
           if (!fileSuite)
             continue;
           for (const spec of fileSuite._allSpecs()) {
-            if (grepMatcher(spec.fullTitle()))
+            if (grepMatcher(spec._testFullTitle(project.config.name)))
               project.generateTests(spec);
           }
         }

--- a/src/test.ts
+++ b/src/test.ts
@@ -38,10 +38,6 @@ class Base {
       return this.parent.titlePath();
     return [...this.parent.titlePath(), this.title];
   }
-
-  fullTitle(): string {
-    return this.titlePath().join(' ');
-  }
 }
 
 export class Spec extends Base implements reporterTypes.Spec {
@@ -60,6 +56,14 @@ export class Spec extends Base implements reporterTypes.Spec {
 
   ok(): boolean {
     return !this.tests.find(r => !r.ok());
+  }
+
+  fullTitle(): string {
+    return this.titlePath().join(' ');
+  }
+
+  _testFullTitle(projectName: string) {
+    return (projectName ? `[${projectName}] ` : '') + this.fullTitle();
   }
 }
 
@@ -198,6 +202,10 @@ export class Test implements reporterTypes.Test {
   ok(): boolean {
     const status = this.status();
     return status === 'expected' || status === 'flaky' || status === 'skipped';
+  }
+
+  fullTitle(): string {
+    return this.spec._testFullTitle(this.projectName);
   }
 
   _appendTestResult(): reporterTypes.TestResult {

--- a/test/config.spec.ts
+++ b/test/config.spec.ts
@@ -376,7 +376,7 @@ test('should throw when test() is called in config file', async ({ runInlineTest
   expect(result.output).toContain('test() can only be called in a test file');
 });
 
-test('should filter by project', async ({ runInlineTest }) => {
+test('should filter by project, case-insensitive', async ({ runInlineTest }) => {
   const { passed, failed, output, skipped } = await runInlineTest({
     'folio.config.ts': `
       module.exports = { projects: [
@@ -390,7 +390,7 @@ test('should filter by project', async ({ runInlineTest }) => {
         console.log(testInfo.project.name);
       });
     `
-  }, { project: 'suite2' });
+  }, { project: 'SUite2' });
   expect(passed).toBe(1);
   expect(failed).toBe(0);
   expect(skipped).toBe(0);

--- a/test/fixtures.spec.ts
+++ b/test/fixtures.spec.ts
@@ -50,7 +50,9 @@ test('should work with a sync fixture function', async ({ runInlineTest }) => {
   const { results } = await runInlineTest({
     'a.test.js': `
       const test = folio.test.extend({
-        asdf: ({}, use) => use(123),
+        asdf: ({}, use) => {
+          use(123);
+        },
       });
 
       test('should use asdf', ({asdf}) => {

--- a/test/golden.spec.ts
+++ b/test/golden.spec.ts
@@ -75,7 +75,7 @@ test('should write missing expectations locally', async ({runInlineTest}, testIn
     `
   }, {}, { CI: '' });
   expect(result.exitCode).toBe(1);
-  expect(result.output).toContain('snapshot.txt is missing in golden results, writing actual');
+  expect(result.output).toContain('snapshot.txt is missing in snapshots, writing actual');
   const data = fs.readFileSync(testInfo.outputPath('__snapshots__/a/is-a-test/snapshot.txt'));
   expect(data.toString()).toBe('Hello world');
 });
@@ -90,7 +90,7 @@ test('should not write missing expectations on CI', async ({runInlineTest}, test
     `
   }, {}, { CI: '1' });
   expect(result.exitCode).toBe(1);
-  expect(result.output).toContain('snapshot.txt is missing in golden results');
+  expect(result.output).toContain('snapshot.txt is missing in snapshots');
   expect(fs.existsSync(testInfo.outputPath('__snapshots__/a/is-a-test/snapshot.txt'))).toBe(false);
 });
 
@@ -105,8 +105,7 @@ test('should update expectations', async ({runInlineTest}, testInfo) => {
     `
   }, { 'update-snapshots': true });
   expect(result.exitCode).toBe(0);
-  expect(result.output).toContain('Updating snapshot at');
-  expect(result.output).toContain('snapshot.txt');
+  expect(result.output).toContain('snapshot.txt does not match, writing actual.');
   const data = fs.readFileSync(testInfo.outputPath('__snapshots__/a/is-a-test/snapshot.txt'));
   expect(data.toString()).toBe('Hello world updated');
 });

--- a/test/match-grep.spec.ts
+++ b/test/match-grep.spec.ts
@@ -78,3 +78,21 @@ test('should grep test name with //', async ({ runInlineTest }) => {
   expect(result.passed).toBe(3);
   expect(result.exitCode).toBe(0);
 });
+
+test('should grep by project name', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'folio.config.ts': `
+      module.exports = { projects: [
+        { name: 'foo' },
+        { name: 'bar' },
+      ]};
+    `,
+    'a.spec.ts': `
+      folio.test('should work', () => {});
+    `,
+  }, { 'grep': 'foo]' });
+  expect(result.passed).toBe(1);
+  expect(result.skipped).toBe(0);
+  expect(result.failed).toBe(0);
+  expect(result.exitCode).toBe(0);
+});


### PR DESCRIPTION
- Sync fixture functions actually work now.
- Test title grep includes project name.
- `--update-snapshots` does not fail when updating missing snapshot.
- `--project` performs case-insensitive comparison.
- README has more empty lines and file names in all snippets.