### PR TITLE
feat(snapshots): change snapshots location

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,7 +422,7 @@ test('my test', async () => {
 });
 ```
 
-Snapshots are stored under `__snapshots__` directory by default, and can be specified in the [configuration object](#configuration-object).
+Snapshots are stored next to the test files, and you should commit them to the version control system.
 
 ## Parallelism and sharding
 
@@ -602,7 +602,6 @@ Test project configuration properties:
 - `outputDir: string` - Output directory for files created during the test run.
 - `repeatEach: number` - The number of times to repeat each test, useful for debugging flaky tests. Overridden by `--repeat-each` command line option.
 - `retries: number` - The maximum number of retry attempts given to failed tests. Overridden by `--retries` command line option.
-- `snapshotDir: string` - [Snapshots](#snapshots) directory. Overridden by `--snapshot-dir` command line option.
 - `testDir: string` - Directory that will be recursively scanned for test files.
 - `testIgnore: string | RegExp | (string | RegExp)[]` - Files matching one of these patterns are not considered test files.
 - `testMatch: string | RegExp | (string | RegExp)[]` - Only the files matching one of these patterns are considered test files.
@@ -704,7 +703,7 @@ export default config;
 ```
 
 Each project can be configured separately, and run different set of tests with different parameters.
-Supported options are `name`, `outputDir`, `repeatEach`, `retries`, `snapshotDir`, `testDir`, `testIgnore`, `testMatch` and `timeout`. See [configuration object](#configuration-object) for detailed description.
+Supported options are `name`, `outputDir`, `repeatEach`, `retries`, `testDir`, `testIgnore`, `testMatch` and `timeout`. See [configuration object](#configuration-object) for detailed description.
 
 You can run all projects or just a single one:
 ```sh
@@ -765,8 +764,8 @@ In addition to everything from the [`workerInfo`](#workerinfo), the following in
 - `expectedStatus: 'passed' | 'failed' | 'timedOut'` - Whether this test is expected to pass, fail or timeout.
 - `timeout: number` - Test timeout.
 - `annotations` - [Annotations](#annotations) that were added to the test.
-- `snapshotPathSegment: string` - Relative path, used to locate snapshots for the test.
-- `snapshotPath(...pathSegments: string[])` - Function that returns the full path to a particular snapshot for the test.
+- `snapshotSuffix: string` - Suffix used to locate snapshots for the test.
+- `snapshotPath(snapshotName: string)` - Function that returns the full path to a particular snapshot for the test.
 - `outputDir: string` - Absolute path to the output directory for this test run.
 - `outputPath(...pathSegments: string[])` - Function that returns the full path to a particular output artifact for the test.
 

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -164,22 +164,11 @@ export class Loader {
     if (!path.isAbsolute(testDir))
       testDir = path.resolve(rootDir, testDir);
 
-    const useRootDirForSnapshots = !projectConfig.snapshotDir && !!this._config.snapshotDir;
-    let snapshotDir = '';
-    if (useRootDirForSnapshots) {
-      if (!path.isAbsolute(this._config.snapshotDir) && !('testDir' in this._config))
-        throw new Error(`When using projects, passing relative "snapshotDir" in the root requires "testDir"`);
-      snapshotDir = path.isAbsolute(this._config.snapshotDir) ? this._config.snapshotDir : path.resolve(this._config.testDir, this._config.snapshotDir);
-    } else {
-      snapshotDir = path.resolve(testDir, projectConfig.snapshotDir || '__snapshots__');
-    }
-
     const fullProject: FullProject = {
       define: projectConfig.define || [],
       outputDir: takeFirst(this._configOverrides.outputDir, projectConfig.outputDir, this._config.outputDir, path.resolve(process.cwd(), 'test-results')),
       repeatEach: takeFirst(this._configOverrides.repeatEach, projectConfig.repeatEach, this._config.repeatEach, 1),
       retries: takeFirst(this._configOverrides.retries, projectConfig.retries, this._config.retries, 0),
-      snapshotDir,
       metadata: projectConfig.metadata,
       name: projectConfig.name || '',
       testDir,
@@ -188,7 +177,7 @@ export class Loader {
       timeout: takeFirst(this._configOverrides.timeout, projectConfig.timeout, this._config.timeout, this._defaultTimeout),
       use: projectConfig.use || {},
     };
-    this._projects.push(new ProjectImpl(fullProject, this._projects.length, useRootDirForSnapshots));
+    this._projects.push(new ProjectImpl(fullProject, this._projects.length));
   }
 }
 

--- a/src/project.ts
+++ b/src/project.ts
@@ -21,16 +21,14 @@ import { DeclaredFixtures, TestTypeImpl } from './testType';
 
 export class ProjectImpl {
   config: FullProject;
-  readonly useRootDirForSnapshots: boolean;
   private index: number;
   private defines = new Map<TestType<any, any>, Fixtures>();
   private testTypePools = new Map<TestTypeImpl, FixturePool>();
   private specPools = new Map<Spec, FixturePool>();
 
-  constructor(project: FullProject, index: number, useRootDirForSnapshots: boolean) {
+  constructor(project: FullProject, index: number) {
     this.config = project;
     this.index = index;
-    this.useRootDirForSnapshots = useRootDirForSnapshots;
     this.defines = new Map();
     for (const { test, fixtures } of Array.isArray(project.define) ? project.define : [project.define])
       this.defines.set(test, fixtures);

--- a/src/reporters/json.ts
+++ b/src/reporters/json.ts
@@ -72,7 +72,6 @@ class JSONReporter extends EmptyReporter {
             outputDir: toPosixPath(project.outputDir),
             repeatEach: project.repeatEach,
             retries: project.retries,
-            snapshotDir: toPosixPath(project.snapshotDir),
             metadata: project.metadata,
             name: project.name,
             testDir: toPosixPath(project.testDir),

--- a/src/types.ts
+++ b/src/types.ts
@@ -61,11 +61,6 @@ interface ProjectBase {
   retries?: number;
 
   /**
-   * Directory containing all snapshots, used by `expect(value).toMatchSnapshot()`.
-   */
-  snapshotDir?: string;
-
-  /**
    * Directory that will be recursively scanned for test files.
    */
   testDir?: string;
@@ -378,11 +373,11 @@ export interface TestInfo extends WorkerInfo {
   stderr: (string | Buffer)[];
 
   /**
-   * Relative path segment used to differentiate snapshots between multiple test configurations.
+   * Suffix used to differentiate snapshots between multiple test configurations.
    * For example, if snapshots depend on the platform, you can set `testInfo.snapshotPathSegment = process.platform`,
    * and `expect(value).toMatchSnapshot()` will use different snapshots depending on the platform.
    */
-  snapshotPathSegment: string;
+  snapshotSuffix: string;
 
   /**
    * Absolute path to the output directory for this specific test run.
@@ -393,7 +388,7 @@ export interface TestInfo extends WorkerInfo {
   /**
    * Returns a path to a snapshot file.
    */
-  snapshotPath: (...pathSegments: string[]) => string;
+  snapshotPath: (snapshotName: string) => string;
 
   /**
    * Returns a path inside the `outputDir` where the test can safely put a temporary file.

--- a/src/workerRunner.ts
+++ b/src/workerRunner.ts
@@ -181,10 +181,9 @@ export class WorkerRunner extends EventEmitter {
     let deadlineRunner: DeadlineRunner<any> | undefined;
     const testId = test._id;
 
-    const relativeTestFilePath = path.relative(this._project.config.testDir, spec.file.replace(/\.(spec|test)\.(js|ts)/, ''));
-    const relativeTestFilePathForSnapshots = path.relative(this._project.useRootDirForSnapshots ? this._loader.fullConfig().rootDir : this._project.config.testDir, spec.file.replace(/\.(spec|test)\.(js|ts)/, ''));
     const sanitizedTitle = spec.title.replace(/[^\w\d]+/g, '-');
     const baseOutputDir = (() => {
+      const relativeTestFilePath = path.relative(this._project.config.testDir, spec.file.replace(/\.(spec|test)\.(js|ts)/, ''));
       const sanitizedRelativePath = relativeTestFilePath.replace(process.platform === 'win32' ? new RegExp('\\\\', 'g') : new RegExp('/', 'g'), '-');
       let testOutputDir = sanitizedRelativePath + '-' + sanitizedTitle + this._outputPathSegment;
       if (entry.retry)
@@ -210,15 +209,14 @@ export class WorkerRunner extends EventEmitter {
       stdout: [],
       stderr: [],
       timeout: this._project.config.timeout,
-      snapshotPathSegment: '',
+      snapshotSuffix: '',
       outputDir: baseOutputDir,
       outputPath: (...pathSegments: string[]): string => {
         fs.mkdirSync(baseOutputDir, { recursive: true });
         return path.join(baseOutputDir, ...pathSegments);
       },
-      snapshotPath: (...pathSegments: string[]): string => {
-        const basePath = path.join(this._project.config.snapshotDir, relativeTestFilePathForSnapshots, sanitizedTitle, testInfo.snapshotPathSegment);
-        return path.join(basePath, ...pathSegments);
+      snapshotPath: (snapshotName: string): string => {
+        return path.join(spec.file + '-snapshots', sanitizedTitle + (testInfo.snapshotSuffix ? '-' : '') + testInfo.snapshotSuffix + '-' + snapshotName);
       },
       skip: (...args: [arg?: any, description?: string]) => modifier(testInfo, 'skip', args),
       fixme: (...args: [arg?: any, description?: string]) => modifier(testInfo, 'fixme', args),

--- a/test/golden.spec.ts
+++ b/test/golden.spec.ts
@@ -21,7 +21,7 @@ import { test, expect } from './folio-test';
 
 test('should support golden', async ({runInlineTest}) => {
   const result = await runInlineTest({
-    '__snapshots__/a/is-a-test/snapshot.txt': `Hello world`,
+    'a.spec.js-snapshots/is-a-test-snapshot.txt': `Hello world`,
     'a.spec.js': `
       const { test } = folio;
       test('is a test', ({}) => {
@@ -34,7 +34,7 @@ test('should support golden', async ({runInlineTest}) => {
 
 test('should fail on wrong golden', async ({runInlineTest}) => {
   const result = await runInlineTest({
-    '__snapshots__/a/is-a-test/snapshot.txt': `Line1
+    'a.spec.js-snapshots/is-a-test-snapshot.txt': `Line1
 Line2
 Line3
 Hello world line1
@@ -76,7 +76,7 @@ test('should write missing expectations locally', async ({runInlineTest}, testIn
   }, {}, { CI: '' });
   expect(result.exitCode).toBe(1);
   expect(result.output).toContain('snapshot.txt is missing in snapshots, writing actual');
-  const data = fs.readFileSync(testInfo.outputPath('__snapshots__/a/is-a-test/snapshot.txt'));
+  const data = fs.readFileSync(testInfo.outputPath('a.spec.js-snapshots/is-a-test-snapshot.txt'));
   expect(data.toString()).toBe('Hello world');
 });
 
@@ -91,12 +91,12 @@ test('should not write missing expectations on CI', async ({runInlineTest}, test
   }, {}, { CI: '1' });
   expect(result.exitCode).toBe(1);
   expect(result.output).toContain('snapshot.txt is missing in snapshots');
-  expect(fs.existsSync(testInfo.outputPath('__snapshots__/a/is-a-test/snapshot.txt'))).toBe(false);
+  expect(fs.existsSync(testInfo.outputPath('a.spec.js-snapshots/is-a-test-snapshot.txt'))).toBe(false);
 });
 
 test('should update expectations', async ({runInlineTest}, testInfo) => {
   const result = await runInlineTest({
-    '__snapshots__/a/is-a-test/snapshot.txt': `Hello world`,
+    'a.spec.js-snapshots/is-a-test-snapshot.txt': `Hello world`,
     'a.spec.js': `
       const { test } = folio;
       test('is a test', ({}) => {
@@ -106,15 +106,15 @@ test('should update expectations', async ({runInlineTest}, testInfo) => {
   }, { 'update-snapshots': true });
   expect(result.exitCode).toBe(0);
   expect(result.output).toContain('snapshot.txt does not match, writing actual.');
-  const data = fs.readFileSync(testInfo.outputPath('__snapshots__/a/is-a-test/snapshot.txt'));
+  const data = fs.readFileSync(testInfo.outputPath('a.spec.js-snapshots/is-a-test-snapshot.txt'));
   expect(data.toString()).toBe('Hello world updated');
 });
 
 test('should match multiple snapshots', async ({runInlineTest}) => {
   const result = await runInlineTest({
-    '__snapshots__/a/is-a-test/snapshot.txt': `Snapshot1`,
-    '__snapshots__/a/is-a-test/snapshot_1.txt': `Snapshot2`,
-    '__snapshots__/a/is-a-test/snapshot_2.txt': `Snapshot3`,
+    'a.spec.js-snapshots/is-a-test-snapshot.txt': `Snapshot1`,
+    'a.spec.js-snapshots/is-a-test-snapshot_1.txt': `Snapshot2`,
+    'a.spec.js-snapshots/is-a-test-snapshot_2.txt': `Snapshot3`,
     'a.spec.js': `
       const { test } = folio;
       test('is a test', ({}) => {
@@ -133,7 +133,7 @@ test('should match snapshots from multiple projects', async ({runInlineTest}) =>
       import * as path from 'path';
       module.exports = { projects: [
         { testDir: path.join(__dirname, 'p1') },
-        { testDir: path.join(__dirname, 'p2'), snapshotDir: 'my-snapshots' },
+        { testDir: path.join(__dirname, 'p2') },
       ]};
     `,
     'p1/a.spec.js': `
@@ -142,98 +142,21 @@ test('should match snapshots from multiple projects', async ({runInlineTest}) =>
         expect('Snapshot1').toMatchSnapshot();
       });
     `,
-    'p1/__snapshots__/a/is-a-test/snapshot.txt': `Snapshot1`,
+    'p1/a.spec.js-snapshots/is-a-test-snapshot.txt': `Snapshot1`,
     'p2/a.spec.js': `
       const { test } = folio;
       test('is a test', ({}) => {
         expect('Snapshot2').toMatchSnapshot();
       });
     `,
-    'p2/my-snapshots/a/is-a-test/snapshot.txt': `Snapshot2`,
+    'p2/a.spec.js-snapshots/is-a-test-snapshot.txt': `Snapshot2`,
   });
   expect(result.exitCode).toBe(0);
-});
-
-test('should match snapshots from multiple projects sharing the snapshots dir', async ({runInlineTest}) => {
-  const result = await runInlineTest({
-    'folio.config.ts': `
-      import * as path from 'path';
-      module.exports = { projects: [
-        { testDir: __dirname },
-        { testDir: __dirname },
-        { testDir: path.join(__dirname, 'dir') },
-      ], snapshotDir: path.join(__dirname, '__snapshots__') };
-    `,
-    'a.spec.js': `
-      const { test } = folio;
-      test('is a test', ({}) => {
-        expect('Snapshot1').toMatchSnapshot();
-      });
-    `,
-    '__snapshots__/a/is-a-test/snapshot.txt': `Snapshot1`,
-    'dir/a.spec.js': `
-      const { test } = folio;
-      test('is a test', ({}) => {
-        expect('Snapshot2').toMatchSnapshot();
-      });
-    `,
-    '__snapshots__/dir/a/is-a-test/snapshot.txt': `Snapshot2`,
-  });
-  expect(result.exitCode).toBe(0);
-});
-
-test('should match snapshots from multiple projects sharing the relative snapshots dir', async ({runInlineTest}) => {
-  const result = await runInlineTest({
-    'folio.config.ts': `
-      import * as path from 'path';
-      module.exports = {
-        testDir: __dirname,
-        snapshotDir: '__snapshots__' ,
-        projects: [
-          {},
-          { testDir: path.join(__dirname, 'dir') },
-        ],
-      };
-    `,
-    'a.spec.js': `
-      const { test } = folio;
-      test('is a test', ({}) => {
-        expect('Snapshot1').toMatchSnapshot();
-      });
-    `,
-    '__snapshots__/a/is-a-test/snapshot.txt': `Snapshot1`,
-    'dir/a.spec.js': `
-      const { test } = folio;
-      test('is a test', ({}) => {
-        expect('Snapshot2').toMatchSnapshot();
-      });
-    `,
-    '__snapshots__/dir/a/is-a-test/snapshot.txt': `Snapshot2`,
-  });
-  expect(result.exitCode).toBe(0);
-});
-
-test('should throw for relative snapshotDir in the root', async ({runInlineTest}) => {
-  const result = await runInlineTest({
-    'folio.config.ts': `
-      import * as path from 'path';
-      module.exports = { projects: [
-        { testDir: __dirname },
-      ], snapshotDir: '__snapshots__' };
-    `,
-    'a.spec.js': `
-      const { test } = folio;
-      test('is a test', ({}) => {
-      });
-    `,
-  });
-  expect(result.exitCode).toBe(1);
-  expect(result.output).toContain(`When using projects, passing relative "snapshotDir" in the root requires "testDir"`);
 });
 
 test('should use provided name', async ({runInlineTest}) => {
   const result = await runInlineTest({
-    '__snapshots__/a/is-a-test/provided.txt': `Hello world`,
+    'a.spec.js-snapshots/is-a-test-provided.txt': `Hello world`,
     'a.spec.js': `
       const { test } = folio;
       test('is a test', ({}) => {
@@ -246,7 +169,7 @@ test('should use provided name', async ({runInlineTest}) => {
 
 test('should use provided name via options', async ({runInlineTest}) => {
   const result = await runInlineTest({
-    '__snapshots__/a/is-a-test/provided.txt': `Hello world`,
+    'a.spec.js-snapshots/is-a-test-provided.txt': `Hello world`,
     'a.spec.js': `
       const { test } = folio;
       test('is a test', ({}) => {
@@ -259,7 +182,7 @@ test('should use provided name via options', async ({runInlineTest}) => {
 
 test('should compare binary', async ({runInlineTest}) => {
   const result = await runInlineTest({
-    '__snapshots__/a/is-a-test/snapshot.dat': Buffer.from([1,2,3,4]),
+    'a.spec.js-snapshots/is-a-test-snapshot.dat': Buffer.from([1,2,3,4]),
     'a.spec.js': `
       const { test } = folio;
       test('is a test', ({}) => {
@@ -272,7 +195,7 @@ test('should compare binary', async ({runInlineTest}) => {
 
 test('should compare PNG images', async ({runInlineTest}) => {
   const result = await runInlineTest({
-    '__snapshots__/a/is-a-test/snapshot.png':
+    'a.spec.js-snapshots/is-a-test-snapshot.png':
         Buffer.from('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+P+/HgAFhAJ/wlseKgAAAABJRU5ErkJggg==', 'base64'),
     'a.spec.js': `
       const { test } = folio;
@@ -286,7 +209,7 @@ test('should compare PNG images', async ({runInlineTest}) => {
 
 test('should compare different PNG images', async ({runInlineTest}) => {
   const result = await runInlineTest({
-    '__snapshots__/a/is-a-test/snapshot.png':
+    'a.spec.js-snapshots/is-a-test-snapshot.png':
         Buffer.from('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+P+/HgAFhAJ/wlseKgAAAABJRU5ErkJggg==', 'base64'),
     'a.spec.js': `
       const { test } = folio;
@@ -304,8 +227,8 @@ test('should respect threshold', async ({runInlineTest}) => {
   const expected = fs.readFileSync(path.join(__dirname, 'assets/screenshot-canvas-expected.png'));
   const actual = fs.readFileSync(path.join(__dirname, 'assets/screenshot-canvas-actual.png'));
   const result = await runInlineTest({
-    '__snapshots__/a/is-a-test/snapshot.png': expected,
-    '__snapshots__/a/is-a-test/snapshot2.png': expected,
+    'a.spec.js-snapshots/is-a-test-snapshot.png': expected,
+    'a.spec.js-snapshots/is-a-test-snapshot2.png': expected,
     'a.spec.js': `
       const { test } = folio;
       test('is a test', ({}) => {

--- a/test/test-output-dir.spec.ts
+++ b/test/test-output-dir.spec.ts
@@ -81,13 +81,13 @@ test('should include the project name', async ({ runInlineTest }) => {
     'helper.ts': `
       export const test = folio.test.extend({
         auto: [ async ({}, run, testInfo) => {
-          testInfo.snapshotPathSegment = 'snapshots1';
+          testInfo.snapshotSuffix = 'snapshots1';
           await run();
         }, { auto: true } ]
       });
       export const test2 = folio.test.extend({
         auto: [ async ({}, run, testInfo) => {
-          testInfo.snapshotPathSegment = 'snapshots2';
+          testInfo.snapshotSuffix = 'snapshots2';
           await run();
         }, { auto: true } ]
       });
@@ -119,33 +119,33 @@ test('should include the project name', async ({ runInlineTest }) => {
 
   // test1, run with foo #1
   expect(result.output).toContain('test-results/my-test-test-1-foo1/bar.txt');
-  expect(result.output).toContain('__snapshots__/my-test/test-1/snapshots1/bar.txt');
+  expect(result.output).toContain('my-test.spec.js-snapshots/test-1-snapshots1-bar.txt');
   expect(result.output).toContain('test-results/my-test-test-1-foo1-retry1/bar.txt');
-  expect(result.output).toContain('__snapshots__/my-test/test-1/snapshots1/bar.txt');
+  expect(result.output).toContain('my-test.spec.js-snapshots/test-1-snapshots1-bar.txt');
 
   // test1, run with foo #2
   expect(result.output).toContain('test-results/my-test-test-1-foo2/bar.txt');
-  expect(result.output).toContain('__snapshots__/my-test/test-1/snapshots1/bar.txt');
+  expect(result.output).toContain('my-test.spec.js-snapshots/test-1-snapshots1-bar.txt');
   expect(result.output).toContain('test-results/my-test-test-1-foo2-retry1/bar.txt');
-  expect(result.output).toContain('__snapshots__/my-test/test-1/snapshots1/bar.txt');
+  expect(result.output).toContain('my-test.spec.js-snapshots/test-1-snapshots1-bar.txt');
 
   // test1, run with bar
   expect(result.output).toContain('test-results/my-test-test-1-bar/bar.txt');
-  expect(result.output).toContain('__snapshots__/my-test/test-1/snapshots1/bar.txt');
+  expect(result.output).toContain('my-test.spec.js-snapshots/test-1-snapshots1-bar.txt');
   expect(result.output).toContain('test-results/my-test-test-1-bar-retry1/bar.txt');
-  expect(result.output).toContain('__snapshots__/my-test/test-1/snapshots1/bar.txt');
+  expect(result.output).toContain('my-test.spec.js-snapshots/test-1-snapshots1-bar.txt');
 
   // test2, run with foo #1
   expect(result.output).toContain('test-results/my-test-test-2-foo1/bar.txt');
-  expect(result.output).toContain('__snapshots__/my-test/test-2/snapshots2/bar.txt');
+  expect(result.output).toContain('my-test.spec.js-snapshots/test-2-snapshots2-bar.txt');
 
   // test2, run with foo #2
   expect(result.output).toContain('test-results/my-test-test-2-foo2/bar.txt');
-  expect(result.output).toContain('__snapshots__/my-test/test-2/snapshots2/bar.txt');
+  expect(result.output).toContain('my-test.spec.js-snapshots/test-2-snapshots2-bar.txt');
 
   // test2, run with bar
   expect(result.output).toContain('test-results/my-test-test-2-bar/bar.txt');
-  expect(result.output).toContain('__snapshots__/my-test/test-2/snapshots2/bar.txt');
+  expect(result.output).toContain('my-test.spec.js-snapshots/test-2-snapshots2-bar.txt');
 });
 
 test('should remove output dirs for projects run', async ({runInlineTest}, testInfo) => {


### PR DESCRIPTION
Instead of `__snapshots__/path/to/file/test-name/suffix/file.png`
we now have `path/to/file.spec.ts-snapshots/test-name-suffix-file.png`.