### PR TITLE
feat(global setup): allow returning teardown

### DIFF
--- a/src/loader.ts
+++ b/src/loader.ts
@@ -124,12 +124,14 @@ export class Loader {
     }
   }
 
-  loadGlobalHook(file: string): () => any {
+  loadGlobalHook(file: string, name: string): (config: FullConfig) => any {
     const revertBabelRequire = installTransform();
     try {
-      const hook = require(file);
+      let hook = require(file);
+      if (hook && typeof hook === 'object' && ('default' in hook))
+        hook = hook['default'];
       if (typeof hook !== 'function')
-        throw errorWithCallLocation(`globalSetup and globalTeardown files must export a single function.`);
+        throw errorWithCallLocation(`${name} file must export a single function.`);
       return hook;
     } catch (e) {
       prependErrorMessage(e, `Error while reading ${file}:\n`);

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -151,8 +151,9 @@ export class Runner {
       testFiles.forEach(file => allTestFiles.add(file));
     }
 
+    let globalSetupResult: any;
     if (config.globalSetup)
-      await this._loader.loadGlobalHook(config.globalSetup)();
+      globalSetupResult = await this._loader.loadGlobalHook(config.globalSetup, 'globalSetup')(this._loader.fullConfig());
     try {
       for (const file of allTestFiles)
         this._loader.loadTestFile(file);
@@ -226,8 +227,10 @@ export class Runner {
         return 'sigint';
       return hasWorkerErrors || rootSuite.findSpec(spec => !spec.ok()) ? 'failed' : 'passed';
     } finally {
+      if (globalSetupResult && typeof globalSetupResult === 'function')
+        await globalSetupResult(this._loader.fullConfig());
       if (config.globalTeardown)
-        await this._loader.loadGlobalHook(config.globalTeardown)();
+        await this._loader.loadGlobalHook(config.globalTeardown, 'globalTeardown')(this._loader.fullConfig());
     }
   }
 }


### PR DESCRIPTION
Drive-by: support `export default` there as well.