### PR TITLE
chore: update deps to match "deps of deps" versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,9 +43,8 @@
     "ms": "^2.1.2",
     "pirates": "^4.0.1",
     "pixelmatch": "^5.2.1",
-    "pngjs": "^5.0.0",
     "rimraf": "^3.0.2",
-    "source-map-support": "^0.5.19",
+    "source-map-support": "^0.4.18",
     "stack-utils": "^2.0.2"
   },
   "devDependencies": {

--- a/src/golden.ts
+++ b/src/golden.ts
@@ -20,9 +20,11 @@ import fs from 'fs';
 import path from 'path';
 import jpeg from 'jpeg-js';
 import pixelmatch from 'pixelmatch';
-import { PNG } from 'pngjs';
 import { diff_match_patch, DIFF_INSERT, DIFF_DELETE, DIFF_EQUAL } from '../third_party/diff_match_patch';
 import { UpdateSnapshots } from './types';
+
+// Note: we require the pngjs version of pixelmatch to avoid version mismatches.
+const { PNG } = require(require.resolve('pngjs', { paths: [require.resolve('pixelmatch')] }));
 
 const extensionToMimeType: { [key: string]: string } = {
   'dat': 'application/octet-string',

--- a/test/base-reporter.spec.ts
+++ b/test/base-reporter.spec.ts
@@ -59,7 +59,7 @@ test('print should print the error name without a message', async ({ runInlineTe
   });
   expect(result.exitCode).toBe(1);
   expect(result.failed).toBe(1);
-  expect(result.output).toContain('FooBarError: ');
+  expect(result.output).toContain('FooBarError');
 });
 
 test('print an error in a codeframe', async ({ runInlineTest }) => {


### PR DESCRIPTION
This way we do not bring two copies of pngs and source-map.